### PR TITLE
Pre-commit hook with gometalinter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+-   repo: https://github.com/gabriel/pre-commit-golang
+    sha: 0efd4687f1c0709db41e144aa89b5b10db7052a1
+    hooks:
+    -   id: go-fmt
+    -   id: go-metalinter


### PR DESCRIPTION
To install, run `pre-commit install`.

After running, to view all gometalinter warnings: `pre-commit run -a`.

The current output is:

```
verify_stream.go:103:5:warning: should omit nil check; len() for nil slices is defined as zero (gosimple)
encrypt_test.go:317::warning: declaration of err shadows declaration at encrypt_test.go:313: (vetshadow)
encrypt_test.go:406::warning: declaration of err shadows declaration at encrypt_test.go:401: (vetshadow)
encrypt_test.go:428::warning: declaration of err shadows declaration at encrypt_test.go:423: (vetshadow)
encoding/basex/encoding.go:275:2:warning: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (gosimple)
armor_test.go:164:11:warning: ftr assigned and not used (ineffassign)
armor_test.go:164:3:warning: m assigned and not used (ineffassign)
armor_test.go:164:16:warning: err assigned and not used (ineffassign)
armor_test.go:164:6:warning: hdr assigned and not used (ineffassign)
frame.go:37:3:warning: brand assigned and not used (ineffassign)
encoding/basex/go_base64_test.go:146:4:warning: count assigned and not used (ineffassign)
encoding/basex/bases.go:17:1:warning: comment on exported var Base58StdEncodingStrict should be of the form "Base58StdEncodingStrict ..." (golint)
encoding/basex/bases.go:28:1:warning: comment on exported var Base62StdEncodingStrict should be of the form "Base62StdEncodingStrict ..." (golint)
encoding/basex/basex_test.go:102:11:warning: error return value not checked (rand.Read(r)) (errcheck)
encoding/basex/basex_test.go:107:33:warning: error return value not checked (Base62StdEncoding.DecodeString(data)) (errcheck)
encoding/basex/go_base64_test.go:92:16:warning: error return value not checked (encoder.Write([]byte(p.decoded))) (errcheck)
encoding/basex/go_base64_test.go:93:16:warning: error return value not checked (encoder.Close()) (errcheck)
encoding/basex/go_base64_test.go:358:33:warning: error return value not checked (Base58StdEncoding.DecodeString(data)) (errcheck)
common.go:68:1:warning: detachedSignatureInput is unused (deadcode)
packets.go:64:25:warning: sender can be BasePublicKey (interfacer)
armor.go:75:37:warning: unnecessary conversion (unconvert)
packets.go:104:2:warning: unused struct field github.com/keybase/saltpack.signatureBlock._struct (structcheck)
packets.go:16:2:warning: unused struct field github.com/keybase/saltpack.Version._struct (structcheck)
encrypt.go:27:2:warning: unused struct field github.com/keybase/saltpack.encryptStream.didHeader (structcheck)
encrypt.go:28:2:warning: unused struct field github.com/keybase/saltpack.encryptStream.eof (structcheck)
packets.go:56:2:warning: unused struct field github.com/keybase/saltpack.SignatureHeader._struct (structcheck)
packets.go:25:2:warning: unused struct field github.com/keybase/saltpack.EncryptionHeader._struct (structcheck)
packets.go:38:2:warning: unused struct field github.com/keybase/saltpack.encryptionBlock._struct (structcheck)
packets.go:9:2:warning: unused struct field github.com/keybase/saltpack.receiverKeys._struct (structcheck)
decrypt.go:31:6:warning: struct MessageKeyInfo could have size 72 (currently 80) (aligncheck)
```