### PR TITLE
Better handle whitespace in frame

### DIFF
--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -78,7 +78,7 @@ func TestNewlineInFrame(t *testing.T) {
 	plaintext, ciphertext := encryptArmor62RandomData(t, 1024)
 
 	//newline space space tab space
-	ss := []string{ciphertext[0:10], "\n  	 ", ciphertext[11:]}
+	ss := []string{"\n\n>   ", ciphertext[0:10], "\n  	 ", ciphertext[11:]}
 	ciphertext = strings.Join(ss, "")
 
 	_, plaintext2, brand, err := Dearmor62DecryptOpen(ciphertext, kr)

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -77,7 +77,8 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 func TestNewlineInFrame(t *testing.T) {
 	plaintext, ciphertext := encryptArmor62RandomData(t, 1024)
 
-	ss := []string{ciphertext[0:10], "\n   ", ciphertext[11:]}
+	//newline space space tab space
+	ss := []string{ciphertext[0:10], "\n  	 ", ciphertext[11:]}
 	ciphertext = strings.Join(ss, "")
 
 	_, plaintext2, brand, err := Dearmor62DecryptOpen(ciphertext, kr)

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"io/ioutil"
 	"testing"
+	"strings"
 
 	"github.com/keybase/saltpack/encoding/basex"
 )
@@ -71,6 +72,22 @@ func TestDearmor62DecryptSlowReader(t *testing.T) {
 	if !bytes.Equal(plaintext, msg) {
 		t.Fatalf("bad message back out")
 	}
+}
+
+func TestNewlineInFrame(t *testing.T) {
+	plaintext, ciphertext := encryptArmor62RandomData(t, 1024)
+
+	ss := []string{ciphertext[0:10], "\n   ", ciphertext[11:]}
+	ciphertext = strings.Join(ss, "")
+
+	_, plaintext2, brand, err := Dearmor62DecryptOpen(ciphertext, kr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plaintext, plaintext2) {
+		t.Fatalf("bad message back out")
+	}
+	brandCheck(t, brand)
 }
 
 func TestBadArmor62(t *testing.T) {

--- a/frame.go
+++ b/frame.go
@@ -69,7 +69,7 @@ func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand stri
 
 	// strip whitespace
 	re := regexp.MustCompile("[>\\s]+")
-	s := re.ReplaceAllString(m, " ")
+	s := strings.TrimSpace(re.ReplaceAllString(m, " "))
 
 	sffx := getStringForType(typ)
 	if len(sffx) == 0 {

--- a/frame.go
+++ b/frame.go
@@ -5,6 +5,7 @@ package saltpack
 
 import (
 	"strings"
+	"regexp"
 )
 
 type headerOrFooterMarker string
@@ -66,12 +67,16 @@ func getStringForType(typ MessageType) string {
 
 func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand string, err error) {
 
+	// strip whitespace
+	re := regexp.MustCompile("[^\\S+]{1,}")
+	s := re.ReplaceAllString(m, " ")
+
 	sffx := getStringForType(typ)
 	if len(sffx) == 0 {
 		err = makeErrBadFrame("Message type %v not found", typ)
 		return
 	}
-	v := strings.Split(m, " ")
+	v := strings.Split(s, " ")
 	if len(v) != 4 && len(v) != 5 {
 		err = makeErrBadFrame("wrong number of words (%d)", len(v))
 		return

--- a/frame.go
+++ b/frame.go
@@ -68,7 +68,7 @@ func getStringForType(typ MessageType) string {
 func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand string, err error) {
 
 	// strip whitespace
-	re := regexp.MustCompile(">|[^\\S+]{1,}")
+	re := regexp.MustCompile("[>\\s]+")
 	s := re.ReplaceAllString(m, " ")
 
 	sffx := getStringForType(typ)

--- a/frame.go
+++ b/frame.go
@@ -68,7 +68,7 @@ func getStringForType(typ MessageType) string {
 func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand string, err error) {
 
 	// strip whitespace
-	re := regexp.MustCompile("[^\\S+]{1,}")
+	re := regexp.MustCompile(">|[^\\S+]{1,}")
 	s := re.ReplaceAllString(m, " ")
 
 	sffx := getStringForType(typ)

--- a/frame.go
+++ b/frame.go
@@ -67,8 +67,9 @@ func getStringForType(typ MessageType) string {
 
 func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand string, err error) {
 
-	// strip whitespace
-	re := regexp.MustCompile("[>\\s]+")
+	// replace blocks of characters in the set [>\n\r\t ] with a single space, so that Go
+	// can easily parse each piece
+	re := regexp.MustCompile("[>\n\r\t ]+")
 	s := strings.TrimSpace(re.ReplaceAllString(m, " "))
 
 	sffx := getStringForType(typ)

--- a/specs/saltpack_armor.md
+++ b/specs/saltpack_armor.md
@@ -258,36 +258,18 @@ ipsum](https://twitter.com/oconnor663/status/680171387353448448).
 The BaseX payload is surrounded ('framed') by a header and footer. Rules for parsing
 them appear here.
 
-0. For this section, consider the "stripping set" to be the union of all whitespace and
-   the `>` character (for compatibility with mail clients).
 1. Collect input up to the first period. This is the header.
-2. Within the header, convert all blocks of characters in the stripping set to single spaces.
-   That is to say, any contiguous substring of the header where all characters are in the
-   stripping set should be converted to a single space. Then, strip any leading or trailing
-   whitespace. For example, the string
-```
-\n> BEGIN KEYBASE      SALTPACK\n   ENCRYPTED\t\t    MESSAGE
-```
-   should become
-```
-BEGIN KEYBASE SALTPACK ENCRYPTED MESSAGE
-```.
-2. Convert all whitespace to a single space for easy parsing. For example, in Go we match with
-   the regex `[>\\s]+`, which catches all characters in the union of whitespace
-   and `>` (`>` is for compatibility with mail clients that use it for quoting).
-3. Parse the header, asserting that each word matches the expectation. The key checks
-   here are:
-      1. In a header, the first word should be `BEGIN`.
-      2. The next word is the brand, which only needs to match the regex `([a-zA-Z0-9]+)?`.
-         That is to say, alphanumeric or omitted entirely. For example, `KEYBASE`.
-			3. The next word should always be `SALTPACK`.
-      4. After the brand is the message type. This can be `ENCRYPTED MESSAGE`, `SIGNED
-         MESSAGE`, or `DETACHED SIGNATURE`.
-4. Collect input up to the second period. This is the payload. Remove all characters in the
-   stripping set before decoding. If the implementation is streaming, it may decode the
-   payload before the following steps.
-5. Collect input up to the third period. This is the footer.
-6. Assert that the footer matches the header, with `END` instead of `BEGIN` as the first word.
+2. Assert that the header matches the regex
+   ```
+   [>\n\r\t ]+BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE)|(SIGNED[>\n\r\t ]+MESSAGE)|(DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]+
+   ```
+   The optional word is an application name (like 'KEYBASE'). The last two words give the
+   mode of the message.
+3. Collect input up to the second period. This is the payload. Before decoding, strip all
+   characters that match the regex `[>\n\r\t ]`. If the implementation is streaming, it
+   may decode the payload before the following steps.
+4. Collect input up to the third period. This is the footer.
+5. Assert that the footer matches the header, with `END` instead of `BEGIN`.
 
 We use periods to delimit the header and footer to make parsing easier.
 Although we've been careful to avoid special characters in the payload, we're

--- a/specs/saltpack_armor.md
+++ b/specs/saltpack_armor.md
@@ -206,7 +206,7 @@ overflow the extra zero bytes. (There are as many padding bytes as there are
 padding digits, and the digits only go up to 84.) So when the padding bytes are
 stripped, what's left ends up being the same as what was encoded.
 
-We could've generalized this padding scheme to other bases and block sizes. We}
+We could've generalized this padding scheme to other bases and block sizes. We
 would have to be careful with the padding characters, though. We'd want to
 strip off as many output characters as possible without overflowing the padding
 bytes, and at larger block sizes this is more than one-character-per-byte.
@@ -261,13 +261,12 @@ them appear here.
 1. Collect input up to the first period. This is the header.
 2. Assert that the header matches the regex
    ```
-   [>\n\r\t ]+BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE)|(SIGNED[>\n\r\t ]+MESSAGE)|(DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]+
+   [>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE)|(SIGNED[>\n\r\t ]+MESSAGE)|(DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*
    ```
    The optional word is an application name (like 'KEYBASE'). The last two words give the
    mode of the message.
-3. Collect input up to the second period. This is the payload. Before decoding, strip all
-   characters that match the regex `[>\n\r\t ]`. If the implementation is streaming, it
-   may decode the payload before the following steps.
+3. Collect input up to the second period. This is the payload. If the implementation is
+   streaming, it may decode the payload before the following steps.
 4. Collect input up to the third period. This is the footer.
 5. Assert that the footer matches the header, with `END` instead of `BEGIN`.
 
@@ -279,7 +278,8 @@ they only occur one at a time.
 The payload is decoded as follows:
 
 1. Chunk the characters into blocks of 43. The last block may be short.
-2. Decode each of these blocks with BaseX, using the 62-character alphabet
+2. Strip all characters that match the regex `[>\n\r\t ]`.
+3. Decode each of these blocks with BaseX, using the 62-character alphabet
    `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz` (all the
    digits and letters, in ASCII order).
 

--- a/specs/saltpack_armor.md
+++ b/specs/saltpack_armor.md
@@ -267,7 +267,8 @@ them appear here.
       1. In a header, the first word should be `BEGIN`.
       2. The next word is the brand, which only needs to match the regex `([a-zA-Z0-9]+)?`.
          That is to say, alphanumeric or omitted entirely. For example, `KEYBASE`.
-      3. After the brand is the message type. This can be `ENCRYPTED MESSAGE`, `SIGNED
+			3. The next word should always be `SALTPACK`.
+      4. After the brand is the message type. This can be `ENCRYPTED MESSAGE`, `SIGNED
          MESSAGE`, or `DETACHED SIGNATURE`.
 4. Collect input up to the second period. This is the payload. If the implementation
    is streaming, it may decode the payload before the following steps.


### PR DESCRIPTION
`frame.go` now handles arbitrary amounts and combinations of whitespace in between words in either the header or the footer. It doesn't work with whitespace in the middle of a word (e.g. 'KEY BASE'), so the spec has been updated as we decided we don't want it to do that.