### PR TITLE
Clarify the necessary changes to anonymize the sender

### DIFF
--- a/specs/saltpack_encryption.md
+++ b/specs/saltpack_encryption.md
@@ -147,7 +147,7 @@ header:
 
 Encrypting the sender's long-term public key in step #3 allows Alice to stay
 anonymous to Mallory. If Alice wants to be anonymous to Bob as well, she can
-reuse the ephemeral keys as her own in steps #3 and #9. When the ephemeral
+reuse the ephemeral keypair as her own in steps #3 and #9. When the ephemeral
 key and the sender key are the same, clients may indicate that a message is
 "intentionally anonymous" as opposed to "from an unknown sender".
 

--- a/specs/saltpack_encryption.md
+++ b/specs/saltpack_encryption.md
@@ -141,16 +141,15 @@ header:
 
 9. For each recipient, encrypt 32 zero bytes using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's public
-   key, the sender's long-term private key (or the ephemeral private key if
-   the sender is anonymous), and the first 24 bytes of the **header hash**
-   from #8 as a nonce. Take the last 32 bytes of each box. These are the
-   **MAC keys**.
+   key, the sender's long-term private key, and the first 24 bytes of the
+   **header hash** from #8 as a nonce. Take the last 32 bytes of each box.
+   These are the **MAC keys**.
 
 Encrypting the sender's long-term public key in step #3 allows Alice to stay
 anonymous to Mallory. If Alice wants to be anonymous to Bob as well, she can
-reuse the ephemeral key as her sender key. When the ephemeral key and the
-sender key are the same, clients may indicate that a message is "intentionally
-anonymous" as opposed to "from an unknown sender".
+reuse the ephemeral keys as her own in steps #3 and #9. When the ephemeral
+key and the sender key are the same, clients may indicate that a message is
+"intentionally anonymous" as opposed to "from an unknown sender".
 
 Using the same nonce for each **payload key box** might raise a concern: Are we
 violating the rule against nonce reuse, if for example the recipients list

--- a/specs/saltpack_encryption.md
+++ b/specs/saltpack_encryption.md
@@ -141,9 +141,10 @@ header:
 
 9. For each recipient, encrypt 32 zero bytes using
    [`crypto_box`](http://nacl.cr.yp.to/box.html) with the recipient's public
-   key, the sender's long-term private key, and the first 24 bytes of the
-   **header hash** from #8 as a nonce. Take the last 32 bytes of each box.
-   These are the **MAC keys**.
+   key, the sender's long-term private key (or the ephemeral private key if
+   the sender is anonymous), and the first 24 bytes of the **header hash**
+   from #8 as a nonce. Take the last 32 bytes of each box. These are the
+   **MAC keys**.
 
 Encrypting the sender's long-term public key in step #3 allows Alice to stay
 anonymous to Mallory. If Alice wants to be anonymous to Bob as well, she can


### PR DESCRIPTION
There was no mention of the need to supply the ephemeral private key in step 9 of the spec if the sender wishes to stay anonymous.