### PR TITLE
initial implementation of signcryption

### DIFF
--- a/basic/key.go
+++ b/basic/key.go
@@ -150,6 +150,17 @@ func (k *Keyring) GenerateBoxKey() (*SecretKey, error) {
 	return ret, nil
 }
 
+// CreateEmphemeralKey creates a random ephemeral key. It is not added to the
+// keyring. The BoxPublicKey and Keyring interfaces both support this method,
+// for convenience.
+func (k *Keyring) CreateEphemeralKey() (saltpack.BoxSecretKey, error) {
+	ret, err := generateBoxKey()
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 // GenerateSigningKey generates a signing key and import it into the keyring.
 func (k *Keyring) GenerateSigningKey() (*SigningSecretKey, error) {
 	pub, sec, err := ed25519.GenerateKey(rand.Reader)

--- a/const.go
+++ b/const.go
@@ -24,9 +24,13 @@ const MessageTypeAttachedSignature MessageType = 1
 // detached signature.
 const MessageTypeDetachedSignature MessageType = 2
 
-// SaltpackCurrentVersion is currently the only supported packet
-// version, 1.0.
-var SaltpackCurrentVersion = Version{Major: 1, Minor: 0}
+// MessageTypeSigncryption is a packet type to describe a
+// signcrypted message.
+const MessageTypeSigncryption MessageType = 3
+
+var SaltpackVersion1 = Version{Major: 1, Minor: 0}
+var SaltpackVersion2 = Version{Major: 2, Minor: 0}
+var SaltpackCurrentVersion = SaltpackVersion1
 
 // encryptionBlockSize is by default 1MB and can't currently be tweaked.
 const encryptionBlockSize int = 1048576
@@ -55,6 +59,14 @@ const signatureAttachedString = "saltpack attached signature\x00"
 // a detached signature.
 const signatureDetachedString = "saltpack detached signature\x00"
 
+// signatureEncryptedString is part of the data that is signed in
+// a signcryption signature.
+const signatureEncryptedString = "saltpack encrypted signature\x00"
+
+// signcryptionSymmetricKeyContext gets mixed in with the long term symmetric
+// key and ephemeral key inputs
+const signcryptionSymmetricKeyContext = "saltpack signcryption derived symmetric key\x00"
+
 // We truncate HMAC512 to the same link that NaCl's crypto_auth function does.
 const cryptoAuthBytes = 32
 
@@ -75,6 +87,8 @@ func (m MessageType) String() string {
 		return "a detached signature"
 	case MessageTypeAttachedSignature:
 		return "an attached signature"
+	case MessageTypeSigncryption:
+		return "a signed and encrypted message"
 	default:
 		return "an unknown message type"
 	}

--- a/decrypt.go
+++ b/decrypt.go
@@ -163,7 +163,7 @@ func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, ephemeralKey
 		return nil, nil, -1, ErrBadLookup
 	}
 
-	payloadKeySlice, err := sk.Unbox(ephemeralKey, nonceForPayloadKeyBox(), hdr.Receivers[orig].PayloadKeyBox)
+	payloadKeySlice, err := sk.Unbox(ephemeralKey, nonceForPayloadKeyBoxV1(), hdr.Receivers[orig].PayloadKeyBox)
 	if err != nil {
 		return nil, nil, -1, err
 	}
@@ -191,7 +191,7 @@ func (ds *decryptStream) tryHiddenReceivers(hdr *EncryptionHeader, ephemeralKey 
 
 		for i, r := range hdr.Receivers {
 			if len(r.ReceiverKID) == 0 {
-				payloadKeySlice, err := shared.Unbox(nonceForPayloadKeyBox(), r.PayloadKeyBox)
+				payloadKeySlice, err := shared.Unbox(nonceForPayloadKeyBoxV1(), r.PayloadKeyBox)
 				if err != nil {
 					continue
 				}

--- a/encrypt.go
+++ b/encrypt.go
@@ -151,7 +151,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 	eh.SenderSecretbox = secretbox.Seal([]byte{}, sender.GetPublicKey().ToKID(), (*[24]byte)(nonceForSenderKeySecretBox()), (*[32]byte)(&es.payloadKey))
 
 	for _, receiver := range receivers {
-		payloadKeyBox := ephemeralKey.Box(receiver, nonceForPayloadKeyBox(), es.payloadKey[:])
+		payloadKeyBox := ephemeralKey.Box(receiver, nonceForPayloadKeyBoxV1(), es.payloadKey[:])
 
 		keys := receiverKeys{PayloadKeyBox: payloadKeyBox}
 

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -86,6 +86,18 @@ func (r *keyring) GetAllBoxSecretKeys() (ret []BoxSecretKey) {
 	return ret
 }
 
+func (k *keyring) CreateEphemeralKey() (BoxSecretKey, error) {
+	pk, sk, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	ret := &boxSecretKey{}
+	copy(ret.key[:], (*sk)[:])
+	copy(ret.pub.key[:], (*pk)[:])
+	ret.isInit = true
+	return ret, nil
+}
+
 func (r *keyring) makeIterable() *keyring {
 	return &keyring{
 		keys:     r.keys,

--- a/errors.go
+++ b/errors.go
@@ -62,6 +62,10 @@ var (
 
 	// ErrDecryptionFailed is returned when a decryption fails
 	ErrDecryptionFailed = errors.New("decryption failed")
+
+	// ErrWrongNumberOfKeys is returned when the resolved list of keys isn't
+	// the same length as the identifiers list.
+	ErrWrongNumberOfKeys = errors.New("wrong number of resolved keys")
 )
 
 // ErrBadTag is generated when a payload hash doesn't match the hash

--- a/key.go
+++ b/key.go
@@ -49,8 +49,9 @@ type BoxPublicKey interface {
 	// for use with nacl.box.Seal
 	ToRawBoxKeyPointer() *RawBoxKey
 
-	// CreateEmphemeralKey creates an ephemeral key of the same type,
-	// but totally random.
+	// CreateEmphemeralKey creates an ephemeral key of the same type, but
+	// totally random. The BoxPublicKey and the Keyring interfaces both support
+	// this method, for convenience.
 	CreateEphemeralKey() (BoxSecretKey, error)
 
 	// HideIdentity returns true if we should hide the identity of this
@@ -122,6 +123,11 @@ type Keyring interface {
 	// BoxPublicKey format. This key has never been seen before, so
 	// will be ephemeral.
 	ImportBoxEphemeralKey(kid []byte) BoxPublicKey
+
+	// CreateEmphemeralKey creates a random ephemeral key. It is not added to
+	// the keyring. The BoxPublicKey and Keyring interfaces both support this
+	// method, for convenience.
+	CreateEphemeralKey() (BoxSecretKey, error)
 }
 
 // SigKeyring is an interface used during verification to find

--- a/nonce.go
+++ b/nonce.go
@@ -17,9 +17,21 @@ func nonceForSenderKeySecretBox() *Nonce {
 	return &n
 }
 
-func nonceForPayloadKeyBox() *Nonce {
+func nonceForPayloadKeyBoxV1() *Nonce {
 	var n Nonce
 	copy(n[:], "saltpack_payload_key_box")
+	return &n
+}
+
+func nonceForPayloadKeyBoxV2(recip uint64) *Nonce {
+	var n Nonce
+	copy(n[:], "saltpack_recipsbXXXXXXXX")
+	return &n
+}
+
+func nonceForDerivedSharedKey() *Nonce {
+	var n Nonce
+	copy(n[:], "saltpack_derived_sboxkey")
 	return &n
 }
 
@@ -36,6 +48,17 @@ func nonceForMACKeyBox(headerHash []byte) *Nonce {
 func nonceForChunkSecretBox(i encryptionBlockNumber) *Nonce {
 	var n Nonce
 	copy(n[0:16], "saltpack_ploadsb")
+	binary.BigEndian.PutUint64(n[16:], uint64(i))
+	return &n
+}
+
+// Construct the nonce for the ith block of payload. Differs in one letter from
+// above. There's almost certainly no harm in using the same nonces here as
+// above, since the encryption keys are ephemeral and the signatures already
+// have their own context, but at the same time it's a good practice.
+func nonceForChunkSigncryption(i encryptionBlockNumber) *Nonce {
+	var n Nonce
+	copy(n[0:16], "saltpack_ploadsc")
 	binary.BigEndian.PutUint64(n[16:], uint64(i))
 	return &n
 }

--- a/packets.go
+++ b/packets.go
@@ -18,9 +18,12 @@ type Version struct {
 	Minor   int  `codec:"minor"`
 }
 
-// EncryptionHeader is the first packet in an encrypted message.
-// It contains the encryptions of the session keys, and various
-// message metadata.
+// EncryptionHeader is the first packet in an encrypted message. It contains
+// the encryptions of the session key, and various message metadata. This same
+// struct is used for the signcryption mode as well, though the key types
+// represented by the []byte arrays are different. (For example in the
+// signcryption mode, the sender secretbox contains a *signing* key instead of
+// an encryption key, and the receiver identifier takes a different form.)
 type EncryptionHeader struct {
 	_struct         bool           `codec:",toarray"`
 	FormatName      string         `codec:"format_name"`
@@ -39,6 +42,17 @@ type encryptionBlock struct {
 	HashAuthenticators [][]byte `codec:"authenticators"`
 	PayloadCiphertext  []byte   `codec:"ctext"`
 	seqno              packetSeqno
+}
+
+// The SigncryptionHeader has exactly the same structure as the
+// EncryptionHeader, though the byte slices represent different types of keys.
+type SigncryptionHeader EncryptionHeader
+
+// signcryptionBlock contains a block of signed and encrypted data.
+type signcryptionBlock struct {
+	_struct           bool   `codec:",toarray"`
+	PayloadCiphertext []byte `codec:"ctext"`
+	seqno             packetSeqno
 }
 
 func (h *EncryptionHeader) validate() error {

--- a/packets.go
+++ b/packets.go
@@ -44,6 +44,16 @@ type encryptionBlock struct {
 	seqno              packetSeqno
 }
 
+func (h *EncryptionHeader) validate() error {
+	if h.Type != MessageTypeEncryption {
+		return ErrWrongMessageType{MessageTypeEncryption, h.Type}
+	}
+	if h.Version.Major != SaltpackCurrentVersion.Major {
+		return ErrBadVersion{h.Version}
+	}
+	return nil
+}
+
 // The SigncryptionHeader has exactly the same structure as the
 // EncryptionHeader, though the byte slices represent different types of keys.
 type SigncryptionHeader EncryptionHeader
@@ -55,11 +65,11 @@ type signcryptionBlock struct {
 	seqno             packetSeqno
 }
 
-func (h *EncryptionHeader) validate() error {
-	if h.Type != MessageTypeEncryption {
-		return ErrWrongMessageType{MessageTypeEncryption, h.Type}
+func (h *SigncryptionHeader) validate() error {
+	if h.Type != MessageTypeSigncryption {
+		return ErrWrongMessageType{MessageTypeSigncryption, h.Type}
 	}
-	if h.Version.Major != SaltpackCurrentVersion.Major {
+	if h.Version.Major != SaltpackVersion2.Major {
 		return ErrBadVersion{h.Version}
 	}
 	return nil

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -214,10 +214,9 @@ func (sos *signcryptOpenStream) trySharedSymmetricKeys(hdr *SigncryptionHeader, 
 }
 
 func (sos *signcryptOpenStream) processSigncryptionHeader(hdr *SigncryptionHeader) error {
-	// TODO: check the message type and version
-	// if err := hdr.validate(); err != nil {
-	// 	return err
-	// }
+	if err := hdr.validate(); err != nil {
+		return err
+	}
 
 	ephemeralPub := sos.keyring.ImportBoxEphemeralKey(hdr.Ephemeral)
 

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -139,11 +139,7 @@ func (sos *signcryptOpenStream) tryBoxSecretKeys(hdr *SigncryptionHeader, epheme
 	// one, so this shouldn't be as quadratic as it looks.
 	for receiverIndex, receiver := range hdr.Receivers {
 		for _, derivedKey := range derivedKeys {
-			keyIdentifierDigest := sha512.New()
-			keyIdentifierDigest.Write([]byte("saltpack signcryption derived key identifier\x00"))
-			keyIdentifierDigest.Write(derivedKey[:])
-			keyIdentifierDigest.Write(nonceForPayloadKeyBoxV2(uint64(receiverIndex))[:])
-			identifier := keyIdentifierDigest.Sum(nil)[0:32]
+			identifier := keyIdentifierFromDerivedKey(derivedKey, uint64(receiverIndex))
 			if hmac.Equal(identifier, receiver.ReceiverKID) {
 				// This is the right key! Open the sender secretbox and return the sender key.
 				payloadKey, isValid := secretbox.Open(

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -10,8 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/agl/ed25519"
-
+	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/nacl/secretbox"
 )
 

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -1,0 +1,339 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha512"
+	"io"
+	"io/ioutil"
+
+	"github.com/agl/ed25519"
+
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+type signcryptOpenStream struct {
+	mps              *msgpackStream
+	err              error
+	state            readState
+	payloadKey       *SymmetricKey
+	signingPublicKey SigningPublicKey
+	buf              []byte
+	headerHash       []byte
+	keyring          SigncryptKeyring
+	resolver         SymmetricKeyResolver
+}
+
+func (sos *signcryptOpenStream) Read(b []byte) (n int, err error) {
+	for n == 0 && err == nil {
+		n, err = sos.read(b)
+	}
+	if err == io.EOF && sos.state != stateEndOfStream {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func (sos *signcryptOpenStream) read(b []byte) (n int, err error) {
+
+	// Handle the case of a previous error. Just return the error
+	// again.
+	if sos.err != nil {
+		return 0, sos.err
+	}
+
+	// Handle the case first of a previous read that couldn't put all
+	// of its data into the outgoing buffer.
+	if len(sos.buf) > 0 {
+		n = copy(b, sos.buf)
+		sos.buf = sos.buf[n:]
+		return n, nil
+	}
+
+	// We have two states we can be in, but we can definitely
+	// fall through during one read, so be careful.
+
+	if sos.state == stateBody {
+		var last bool
+		n, last, sos.err = sos.readBlock(b)
+		if sos.err != nil {
+			return 0, sos.err
+		}
+
+		if last {
+			sos.state = stateEndOfStream
+		}
+	}
+
+	if sos.state == stateEndOfStream {
+		sos.err = assertEndOfStream(sos.mps)
+		if sos.err != nil {
+			return 0, sos.err
+		}
+	}
+
+	return n, nil
+}
+
+func (sos *signcryptOpenStream) readHeader(rawReader io.Reader) error {
+	// Read the header bytes.
+	headerBytes := []byte{}
+	seqno, err := sos.mps.Read(&headerBytes)
+	if err != nil {
+		return ErrFailedToReadHeaderBytes
+	}
+	// Compute the header hash.
+	headerHash := sha512.Sum512(headerBytes)
+	sos.headerHash = headerHash[:]
+	// Parse the header bytes.
+	var header SigncryptionHeader
+	err = decodeFromBytes(&header, headerBytes)
+	if err != nil {
+		return err
+	}
+	header.seqno = seqno
+	err = sos.processSigncryptionHeader(&header)
+	if err != nil {
+		return err
+	}
+	sos.state = stateBody
+	return nil
+}
+
+func (sos *signcryptOpenStream) readBlock(b []byte) (n int, lastBlock bool, err error) {
+	var sb signcryptionBlock
+	var seqno packetSeqno
+	seqno, err = sos.mps.Read(&sb)
+	if err != nil {
+		return 0, false, err
+	}
+	sb.seqno = seqno
+	var plaintext []byte
+	plaintext, err = sos.processSigncryptionBlock(&sb)
+	if err != nil {
+		return 0, false, err
+	}
+	if plaintext == nil {
+		return 0, true, err
+	}
+
+	// Copy as much as we can into the given outbuffer
+	n = copy(b, plaintext)
+	// Leave the remainder for a subsequent read
+	sos.buf = plaintext[n:]
+
+	return n, false, err
+}
+
+func (sos *signcryptOpenStream) tryBoxSecretKeys(hdr *SigncryptionHeader, ephemeralPub BoxPublicKey) (*SymmetricKey, error) {
+	derivedKeys := []*SymmetricKey{}
+	for _, receiverBoxSecretKey := range sos.keyring.GetAllBoxSecretKeys() {
+		sharedSecretBox := receiverBoxSecretKey.Box(ephemeralPub, nonceForDerivedSharedKey(), make([]byte, 32))
+		derivedKey, err := symmetricKeyFromSlice(sharedSecretBox[len(sharedSecretBox)-32 : len(sharedSecretBox)])
+		if err != nil {
+			panic(err) // should be statically impossible, if the slice above is the right length
+		}
+		derivedKeys = append(derivedKeys, derivedKey)
+	}
+
+	// Try each of the box secret keys against each of the receiver pairs in
+	// the message header. The actual expected number of box secret keys is
+	// one, so this shouldn't be as quadratic as it looks.
+	for receiverIndex, receiver := range hdr.Receivers {
+		for _, derivedKey := range derivedKeys {
+			keyIdentifierDigest := sha512.New()
+			keyIdentifierDigest.Write([]byte("saltpack signcryption derived key identifier\x00"))
+			keyIdentifierDigest.Write(derivedKey[:])
+			keyIdentifierDigest.Write(nonceForPayloadKeyBoxV2(uint64(receiverIndex))[:])
+			identifier := keyIdentifierDigest.Sum(nil)[0:32]
+			if hmac.Equal(identifier, receiver.ReceiverKID) {
+				// This is the right key! Open the sender secretbox and return the sender key.
+				payloadKey, isValid := secretbox.Open(
+					nil,
+					receiver.PayloadKeyBox,
+					(*[24]byte)(nonceForPayloadKeyBoxV2(uint64(receiverIndex))),
+					(*[32]byte)(derivedKey))
+				if !isValid {
+					return nil, ErrDecryptionFailed
+				}
+				return symmetricKeyFromSlice(payloadKey)
+			}
+		}
+	}
+
+	// None of the box keys worked. We'll fall back to the secretbox keys.
+	return nil, nil
+}
+
+func (sos *signcryptOpenStream) trySharedSymmetricKeys(hdr *SigncryptionHeader, ephemeralPub BoxPublicKey) (*SymmetricKey, error) {
+	identifiers := [][]byte{}
+	for _, receiver := range hdr.Receivers {
+		identifiers = append(identifiers, receiver.ReceiverKID)
+	}
+
+	resolvedKeys, err := sos.resolver.ResolveKeys(identifiers)
+	if err != nil {
+		return nil, err
+	}
+	if len(resolvedKeys) != len(identifiers) {
+		return nil, ErrWrongNumberOfKeys
+	}
+
+	for index, resolved := range resolvedKeys {
+		if resolved == nil {
+			// This key didn't resolve.
+			continue
+		}
+
+		// We got a key. It should decrypt the corresponding receiver secretbox.
+		derivedKeyDigest := sha512.New()
+		derivedKeyDigest.Write([]byte(signcryptionSymmetricKeyContext))
+		derivedKeyDigest.Write(ephemeralPub.ToKID())
+		derivedKeyDigest.Write(resolved[:])
+		derivedKey, err := rawBoxKeyFromSlice(derivedKeyDigest.Sum(nil)[0:32])
+		if err != nil {
+			panic(err) // should be statically impossible, if the slice above is the right length
+		}
+
+		payloadKey, isValid := secretbox.Open(
+			nil,
+			hdr.Receivers[index].PayloadKeyBox,
+			(*[24]byte)(nonceForPayloadKeyBoxV2(uint64(index))),
+			(*[32]byte)(derivedKey))
+		if !isValid {
+			return nil, ErrDecryptionFailed
+		}
+		return symmetricKeyFromSlice(payloadKey)
+	}
+
+	// If we get out of the loop, all the resolved keys were nil (failed to resolve).
+	return nil, nil
+}
+
+func (sos *signcryptOpenStream) processSigncryptionHeader(hdr *SigncryptionHeader) error {
+	// TODO: check the message type and version
+	// if err := hdr.validate(); err != nil {
+	// 	return err
+	// }
+
+	ephemeralPub := sos.keyring.ImportBoxEphemeralKey(hdr.Ephemeral)
+
+	var err error
+	sos.payloadKey, err = sos.tryBoxSecretKeys(hdr, ephemeralPub)
+	if err != nil {
+		return err
+	}
+	if sos.payloadKey == nil {
+		sos.payloadKey, err = sos.trySharedSymmetricKeys(hdr, ephemeralPub)
+		if err != nil {
+			return err
+		}
+	}
+	if sos.payloadKey == nil {
+		return ErrNoDecryptionKey
+	}
+
+	// Decrypt the sender's public key
+	senderKeySlice, ok := secretbox.Open([]byte{}, hdr.SenderSecretbox, (*[24]byte)(nonceForSenderKeySecretBox()), (*[32]byte)(sos.payloadKey))
+	if !ok {
+		return ErrBadSenderKeySecretbox
+	}
+	sos.signingPublicKey = sos.keyring.LookupSigningPublicKey(senderKeySlice)
+
+	// TODO: anonymous mode
+
+	return nil
+}
+
+func (sos *signcryptOpenStream) processSigncryptionBlock(bl *signcryptionBlock) ([]byte, error) {
+
+	blockNum := encryptionBlockNumber(bl.seqno - 1)
+
+	if err := blockNum.check(); err != nil {
+		return nil, err
+	}
+
+	nonce := nonceForChunkSigncryption(blockNum)
+
+	attachedSig, isValid := secretbox.Open([]byte{}, bl.PayloadCiphertext, (*[24]byte)(nonce), (*[32]byte)(sos.payloadKey))
+	if !isValid || len(attachedSig) < ed25519.SignatureSize {
+		return nil, ErrBadCiphertext(bl.seqno)
+	}
+
+	var detachedSig [ed25519.SignatureSize]byte
+	copy(detachedSig[:], attachedSig)
+	chunkPlaintext := attachedSig[ed25519.SignatureSize:]
+
+	plaintextHash := sha512.Sum512(chunkPlaintext)
+
+	signatureInput := []byte(signatureEncryptedString)
+	signatureInput = append(signatureInput, sos.headerHash...)
+	signatureInput = append(signatureInput, nonce[:]...)
+	signatureInput = append(signatureInput, plaintextHash[:]...)
+
+	sigErr := sos.signingPublicKey.Verify(signatureInput, detachedSig[:])
+	if sigErr != nil {
+		return nil, ErrBadSignature
+	}
+
+	// The encoding of the empty buffer implies the EOF.  But otherwise, all mechanisms are the same.
+	if len(chunkPlaintext) == 0 {
+		return nil, nil
+	}
+	return chunkPlaintext, nil
+}
+
+// NewSigncryptOpenStream starts a streaming verification and decryption. It
+// synchronously ingests and parses the given Reader's encryption header. It
+// consults the passed keyring for the decryption keys needed to decrypt the
+// message. On failure, it returns a null Reader and an error message. On
+// success, it returns a Reader with the plaintext stream, and a nil error. In
+// either case, it will return a `MessageKeyInfo` which tells about who the
+// sender was, and which of the Receiver's keys was used to decrypt the
+// message.
+//
+// Note that the caller has an opportunity not to ingest the plaintext if he
+// doesn't trust the sender revealed in the MessageKeyInfo.
+//
+func NewSigncryptOpenStream(r io.Reader, keyring SigncryptKeyring, resolver SymmetricKeyResolver) (senderPub SigningPublicKey, plaintext io.Reader, err error) {
+	sos := &signcryptOpenStream{
+		mps:      newMsgpackStream(r),
+		keyring:  keyring,
+		resolver: resolver,
+	}
+
+	err = sos.readHeader(r)
+	if err != nil {
+		return sos.signingPublicKey, nil, err
+	}
+
+	return sos.signingPublicKey, sos, nil
+}
+
+type SymmetricKeyResolver interface {
+	ResolveKeys(identifiers [][]byte) ([]*SymmetricKey, error)
+}
+
+// Open simply opens a ciphertext given the set of keys in the specified keyring.
+// It returns a plaintext on sucess, and an error on failure. It returns the header's
+// MessageKeyInfo in either case.
+func SigncryptOpen(ciphertext []byte, keyring SigncryptKeyring, resolver SymmetricKeyResolver) (senderPub SigningPublicKey, plaintext []byte, err error) {
+	buf := bytes.NewBuffer(ciphertext)
+	senderPub, plaintextStream, err := NewSigncryptOpenStream(buf, keyring, resolver)
+	if err != nil {
+		return senderPub, nil, err
+	}
+	ret, err := ioutil.ReadAll(plaintextStream)
+	if err != nil {
+		return nil, nil, err
+	}
+	return senderPub, ret, err
+}
+
+type SigncryptKeyring interface {
+	Keyring
+	SigKeyring
+}

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -130,11 +130,7 @@ func (sos *signcryptOpenStream) readBlock(b []byte) (n int, lastBlock bool, err 
 func (sos *signcryptOpenStream) tryBoxSecretKeys(hdr *SigncryptionHeader, ephemeralPub BoxPublicKey) (*SymmetricKey, error) {
 	derivedKeys := []*SymmetricKey{}
 	for _, receiverBoxSecretKey := range sos.keyring.GetAllBoxSecretKeys() {
-		sharedSecretBox := receiverBoxSecretKey.Box(ephemeralPub, nonceForDerivedSharedKey(), make([]byte, 32))
-		derivedKey, err := symmetricKeyFromSlice(sharedSecretBox[len(sharedSecretBox)-32 : len(sharedSecretBox)])
-		if err != nil {
-			panic(err) // should be statically impossible, if the slice above is the right length
-		}
+		derivedKey := derivedEphemeralKeyFromBoxKeys(ephemeralPub, receiverBoxSecretKey)
 		derivedKeys = append(derivedKeys, derivedKey)
 	}
 

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -173,6 +173,10 @@ func receiverEntryForSymmetricKey(receiverSymmetricKey ReceiverSymmetricKey, eph
 	}
 }
 
+// This generates the payload key, and encrypts it for all the different
+// recipients of the two different types. Symmetric key recipients and DH key
+// recipients use different types of identifiers, but they are the same length,
+// and should both be indistinguishable from random noise.
 func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) error {
 	ephemeralKey, err := sss.keyring.CreateEphemeralKey()
 	if err != nil {
@@ -194,6 +198,9 @@ func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSym
 	if sss.signingKey == nil {
 		panic("TODO: anonymous senders")
 	}
+
+	// Collect all the recipient identifiers, and encrypt the payload key for
+	// all of them.
 	eh.SenderSecretbox = secretbox.Seal([]byte{}, sss.signingKey.GetPublicKey().ToKID(), (*[24]byte)(nonceForSenderKeySecretBox()), (*[32]byte)(&sss.encryptionKey))
 
 	var recipientIndex uint64

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -171,7 +171,7 @@ func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSym
 
 	eh := &SigncryptionHeader{
 		FormatName: SaltpackFormatName,
-		Version:    SaltpackCurrentVersion,
+		Version:    SaltpackVersion2,
 		Type:       MessageTypeSigncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 	}

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -1,0 +1,262 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"io"
+
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+type signcryptSealStream struct {
+	output        io.Writer
+	encoder       encoder
+	header        *SigncryptionHeader
+	encryptionKey SymmetricKey
+	signingKey    SigningSecretKey
+	keyring       Keyring
+	buffer        bytes.Buffer
+	inblock       []byte
+	headerHash    []byte
+
+	numBlocks encryptionBlockNumber // the lower 64 bits of the nonce
+
+	didHeader bool
+	eof       bool
+	err       error
+}
+
+func (sss *signcryptSealStream) Write(plaintext []byte) (int, error) {
+
+	if sss.err != nil {
+		return 0, sss.err
+	}
+
+	var ret int
+	if ret, sss.err = sss.buffer.Write(plaintext); sss.err != nil {
+		return 0, sss.err
+	}
+	for sss.buffer.Len() >= encryptionBlockSize {
+		sss.err = sss.signcryptBlock()
+		if sss.err != nil {
+			return 0, sss.err
+		}
+	}
+	return ret, nil
+}
+
+func (sss *signcryptSealStream) signcryptBlock() error {
+	var n int
+	var err error
+	n, err = sss.buffer.Read(sss.inblock[:])
+	if err != nil {
+		return err
+	}
+	return sss.signcryptBytes(sss.inblock[0:n])
+}
+
+func (sss *signcryptSealStream) signcryptBytes(b []byte) error {
+
+	if err := sss.numBlocks.check(); err != nil {
+		return err
+	}
+
+	nonce := nonceForChunkSigncryption(sss.numBlocks)
+
+	plaintextHash := sha512.Sum512(b)
+
+	signatureInput := []byte(signatureEncryptedString)
+	signatureInput = append(signatureInput, sss.headerHash...)
+	signatureInput = append(signatureInput, nonce[:]...)
+	signatureInput = append(signatureInput, plaintextHash[:]...)
+
+	detachedSig, err := sss.signingKey.Sign(signatureInput)
+	if err != nil {
+		return err
+	}
+
+	attachedSig := append(detachedSig, b...)
+
+	ciphertext := secretbox.Seal([]byte{}, attachedSig, (*[24]byte)(nonce), (*[32]byte)(&sss.encryptionKey))
+
+	block := []interface{}{ciphertext}
+
+	if err := sss.encoder.Encode(block); err != nil {
+		return err
+	}
+
+	sss.numBlocks++
+	return nil
+}
+
+func receiverEntryForBoxKey(receiverBoxKey BoxPublicKey, ephemeralPriv BoxSecretKey, payloadKey SymmetricKey, index uint64) receiverKeys {
+	// Derive a shared secret by encrypting zeroes, as in the encryption
+	// format. Multiple recipients could potentially claim the same public key
+	// and share this secret.
+	sharedSecretBox := ephemeralPriv.Box(receiverBoxKey, nonceForDerivedSharedKey(), make([]byte, 32))
+	derivedKey, err := rawBoxKeyFromSlice(sharedSecretBox[len(sharedSecretBox)-32 : len(sharedSecretBox)])
+	if err != nil {
+		panic(err) // should be statically impossible, if the slice above is the right length
+	}
+
+	// Compute the identifier that the receiver will use to find this entry.
+	// Include the recipient index, so that this identifier is unique even if
+	// two recipients claim the same public key (though unfortunately that
+	// means that recipients will need to recompute the identifier for each
+	// entry in the recipients list). This identifier is somewhat redundant,
+	// because a recipient could instead just attempt to decrypt the payload
+	// key secretbox and see if it works, but including them adds a bit to
+	// anonymity by making box key recipients indistinguishable from symmetric
+	// key recipients.
+	keyIdentifierDigest := sha512.New()
+	keyIdentifierDigest.Write([]byte("saltpack signcryption derived key identifier\x00"))
+	keyIdentifierDigest.Write(derivedKey[:])
+	keyIdentifierDigest.Write(nonceForPayloadKeyBoxV2(index)[:])
+	identifier := keyIdentifierDigest.Sum(nil)[0:32]
+
+	payloadKeyBox := secretbox.Seal(
+		nil,
+		payloadKey[:],
+		(*[24]byte)(nonceForPayloadKeyBoxV2(index)),
+		(*[32]byte)(derivedKey))
+
+	return receiverKeys{
+		ReceiverKID:   identifier,
+		PayloadKeyBox: payloadKeyBox,
+	}
+}
+
+type ReceiverSymmetricKey struct {
+	// In practice these identifiers will be KBFS TLF keys.
+	Key SymmetricKey
+	// In practice these identifiers will be KBFS TLF pseudonyms.
+	Identifier []byte
+}
+
+func receiverEntryForSymmetricKey(receiverSymmetricKey ReceiverSymmetricKey, ephemeralPub BoxPublicKey, payloadKey SymmetricKey, index uint64) receiverKeys {
+	// Derive a message-specific shared secret by hashing the symmetric key and
+	// the ephemeral public key together. This lets us use nonces that are
+	// simple counters.
+	derivedKeyDigest := sha512.New()
+	derivedKeyDigest.Write([]byte(signcryptionSymmetricKeyContext))
+	derivedKeyDigest.Write(ephemeralPub.ToKID())
+	derivedKeyDigest.Write(receiverSymmetricKey.Key[:])
+	derivedKey, err := rawBoxKeyFromSlice(derivedKeyDigest.Sum(nil)[0:32])
+	if err != nil {
+		panic(err) // should be statically impossible, if the slice above is the right length
+	}
+
+	payloadKeyBox := secretbox.Seal(
+		nil,
+		payloadKey[:],
+		(*[24]byte)(nonceForPayloadKeyBoxV2(index)),
+		(*[32]byte)(derivedKey))
+
+	// Unlike the box key case, the identifier is supplied by the caller rather
+	// than computed. (These will be KBFS TLF pseudonyms.)
+	return receiverKeys{
+		ReceiverKID:   receiverSymmetricKey.Identifier,
+		PayloadKeyBox: payloadKeyBox,
+	}
+}
+
+func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) error {
+	ephemeralKey, err := sss.keyring.CreateEphemeralKey()
+	if err != nil {
+		return err
+	}
+
+	eh := &SigncryptionHeader{
+		FormatName: SaltpackFormatName,
+		Version:    SaltpackCurrentVersion,
+		Type:       MessageTypeSigncryption,
+		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
+	}
+	sss.header = eh
+	if err := randomFill(sss.encryptionKey[:]); err != nil {
+		return err
+	}
+
+	// TODO: anonymous senders?
+	if sss.signingKey == nil {
+		panic("TODO: anonymous senders")
+	}
+	eh.SenderSecretbox = secretbox.Seal([]byte{}, sss.signingKey.GetPublicKey().ToKID(), (*[24]byte)(nonceForSenderKeySecretBox()), (*[32]byte)(&sss.encryptionKey))
+
+	var recipientIndex uint64
+	for _, receiverBoxKey := range receiverBoxKeys {
+		eh.Receivers = append(eh.Receivers, receiverEntryForBoxKey(receiverBoxKey, ephemeralKey, sss.encryptionKey, recipientIndex))
+		recipientIndex++
+	}
+	for _, receiverSymmetricKey := range receiverSymmetricKeys {
+		eh.Receivers = append(eh.Receivers, receiverEntryForSymmetricKey(receiverSymmetricKey, ephemeralKey.GetPublicKey(), sss.encryptionKey, recipientIndex))
+		recipientIndex++
+	}
+
+	// Encode the header to bytes, hash it, then double encode it.
+	headerBytes, err := encodeToBytes(sss.header)
+	if err != nil {
+		return err
+	}
+	headerHash := sha512.Sum512(headerBytes)
+	sss.headerHash = headerHash[:]
+	err = sss.encoder.Encode(headerBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sss *signcryptSealStream) Close() error {
+	for sss.buffer.Len() > 0 {
+		err := sss.signcryptBlock()
+		if err != nil {
+			return err
+		}
+	}
+	return sss.writeFooter()
+}
+
+func (sss *signcryptSealStream) writeFooter() error {
+	return sss.signcryptBytes([]byte{})
+}
+
+// NewSigncryptSealStream creates a stream that consumes plaintext data. It
+// will write out signed and encrypted data to the io.Writer passed in as
+// ciphertext. The encryption is from the specified sender, and is encrypted
+// for the given receivers.
+//
+// Returns an io.WriteClose that accepts plaintext data to be signcrypted; and
+// also returns an error if initialization failed.
+func NewSigncryptSealStream(ciphertext io.Writer, keyring Keyring, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) (io.WriteCloser, error) {
+	sss := &signcryptSealStream{
+		output:     ciphertext,
+		encoder:    newEncoder(ciphertext),
+		inblock:    make([]byte, encryptionBlockSize),
+		signingKey: sender,
+		keyring:    keyring,
+	}
+	err := sss.init(receiverBoxKeys, receiverSymmetricKeys)
+	return sss, err
+}
+
+// Seal a plaintext from the given sender, for the specified receiver groups.
+// Returns a ciphertext, or an error if something bad happened.
+func SigncryptSeal(plaintext []byte, keyring Keyring, sender SigningSecretKey, receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) (out []byte, err error) {
+	var buf bytes.Buffer
+	sss, err := NewSigncryptSealStream(&buf, keyring, sender, receiverBoxKeys, receiverSymmetricKeys)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := sss.Write(plaintext); err != nil {
+		return nil, err
+	}
+	if err := sss.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/signcrypt_test.go
+++ b/signcrypt_test.go
@@ -1,0 +1,144 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/agl/ed25519"
+	"github.com/stretchr/testify/require"
+)
+
+type testConstResolver struct {
+	hardcodedReceivers []ReceiverSymmetricKey
+}
+
+var _ SymmetricKeyResolver = (*testConstResolver)(nil)
+
+func (r *testConstResolver) ResolveKeys(identifiers [][]byte) ([]*SymmetricKey, error) {
+	ret := []*SymmetricKey{}
+	for _, ident := range identifiers {
+		var key *SymmetricKey
+		for _, receiver := range r.hardcodedReceivers {
+			if bytes.Equal(receiver.Identifier, ident) {
+				key = &receiver.Key
+				break
+			}
+		}
+		ret = append(ret, key)
+	}
+	return ret, nil
+}
+
+func makeEmptyKeyring(t *testing.T) *keyring {
+	keyring := newKeyring()
+	keyring.iterable = true
+	return keyring
+}
+
+func makeKeyringWithOneKey(t *testing.T) (*keyring, []BoxPublicKey) {
+	keyring := makeEmptyKeyring(t)
+	keyring.iterable = true
+	receiverBoxSecretKey, err := keyring.CreateEphemeralKey()
+	require.NoError(t, err)
+	keyring.insert(receiverBoxSecretKey)
+	receiverBoxKeys := []BoxPublicKey{receiverBoxSecretKey.GetPublicKey()}
+	return keyring, receiverBoxKeys
+}
+
+func makeSigningKey(t *testing.T, keyring *keyring) *sigPrivKey {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k := &sigPrivKey{
+		public:  newSigPubKey(*pub),
+		private: *priv,
+	}
+	keyring.insertSigningKey(k)
+	return k
+}
+
+func makeResolverWithOneKey(t *testing.T) (SymmetricKeyResolver, []ReceiverSymmetricKey) {
+	var sharedSymmetricKey SymmetricKey // zeros
+	receiver := ReceiverSymmetricKey{
+		Key:        sharedSymmetricKey,
+		Identifier: []byte("dummy identifier"),
+	}
+	receivers := []ReceiverSymmetricKey{receiver}
+	resolver := &testConstResolver{hardcodedReceivers: receivers}
+	return resolver, receivers
+}
+
+func TestSigncryptionBoxKeyHelloWorld(t *testing.T) {
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealed, err := SigncryptSeal(msg, keyring, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	senderPub, opened, err := SigncryptOpen(sealed, keyring, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, senderPub, senderSigningPrivKey.GetPublicKey())
+
+	require.Equal(t, opened, msg)
+}
+
+func TestSigncryptionResolvedKeyHelloWorld(t *testing.T) {
+	msg := []byte("hello world")
+	keyring := makeEmptyKeyring(t)
+
+	resolver, receivers := makeResolverWithOneKey(t)
+
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealed, err := SigncryptSeal(msg, keyring, senderSigningPrivKey, nil, receivers)
+	require.NoError(t, err)
+
+	senderPub, opened, err := SigncryptOpen(sealed, keyring, resolver)
+	require.NoError(t, err)
+
+	require.Equal(t, senderPub, senderSigningPrivKey.GetPublicKey())
+
+	require.Equal(t, opened, msg)
+}
+
+func TestSigncryptionEmptyCiphertext(t *testing.T) {
+	keyring, _ := makeKeyringWithOneKey(t)
+
+	emptyMessage := []byte("")
+	_, _, err := SigncryptOpen(emptyMessage, keyring, nil)
+	require.Equal(t, err, ErrFailedToReadHeaderBytes)
+}
+
+// This test checks that we throw io.ErrUnexpectedEOF if we reach the end of
+// the stream without having seen a proper termination packet.
+func TestSigncryptionTruncatedAtPacketBoundary(t *testing.T) {
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealed, err := SigncryptSeal(msg, keyring, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	// Figure out how many bytes are in the header packet:
+	// Assert the MessagePack bin8 type.
+	require.Equal(t, byte(0xc4), sealed[0])
+	// Grab the bin length.
+	bin8Len := sealed[1]
+	// Account for the leading two bytes.
+	headerLen := bin8Len + 2
+	// Truncate the message.
+	truncated := sealed[0:headerLen]
+
+	_, _, err = SigncryptOpen(truncated, keyring, nil)
+	require.Equal(t, err, io.ErrUnexpectedEOF)
+}

--- a/signcrypt_test.go
+++ b/signcrypt_test.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/agl/ed25519"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ed25519"
 )
 
 type testConstResolver struct {
@@ -56,8 +56,8 @@ func makeSigningKey(t *testing.T, keyring *keyring) *sigPrivKey {
 		t.Fatal(err)
 	}
 	k := &sigPrivKey{
-		public:  newSigPubKey(*pub),
-		private: *priv,
+		public:  newSigPubKey(pub),
+		private: priv,
 	}
 	keyring.insertSigningKey(k)
 	return k

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -165,7 +165,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 			pes.options.corruptPayloadKey(&payloadKeySlice, rid)
 		}
 
-		nonceTmp := nonceForPayloadKeyBox()
+		nonceTmp := nonceForPayloadKeyBoxV1()
 		if pes.options.corruptKeysNonce != nil {
 			nonceTmp = pes.options.corruptKeysNonce(nonceTmp, rid)
 		}


### PR DESCRIPTION
Add seal and open streams, and a few basic tests. Define an initial
version of the SymmetricKeyResolver, which TLF pseudonym code will
eventually plug into.

r? @maxtaco @mlsteele 