### PR TITLE
Mix ephemeral-static DH output into MAC keys for v2

### DIFF
--- a/basic/key.go
+++ b/basic/key.go
@@ -85,9 +85,9 @@ func (k SecretKey) GetPublicKey() saltpack.BoxPublicKey {
 }
 
 // Precompute computes a shared key with the passed public key.
-func (k SecretKey) Precompute(sender saltpack.BoxPublicKey) saltpack.BoxPrecomputedSharedKey {
+func (k SecretKey) Precompute(peer saltpack.BoxPublicKey) saltpack.BoxPrecomputedSharedKey {
 	var res PrecomputedSharedKey
-	box.Precompute((*[32]byte)(&res), (*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
+	box.Precompute((*[32]byte)(&res), (*[32]byte)(peer.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
 	return res
 }
 

--- a/common.go
+++ b/common.go
@@ -156,7 +156,7 @@ func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public B
 		mac2 := computeMACKeySingle(eSecret, public, headerHash)
 		return sha512.Sum512_256(append(mac1[:], mac2[:]...))
 	default:
-		panic(fmt.Sprintf("Unknown version %s", version))
+		panic(ErrBadVersion{version})
 	}
 }
 
@@ -169,7 +169,7 @@ func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic
 		mac2 := computeMACKeySingle(secret, ePublic, headerHash)
 		return sha512.Sum512_256(append(mac1[:], mac2[:]...))
 	default:
-		panic(fmt.Sprintf("Unknown version %s", version))
+		panic(ErrBadVersion{version})
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -161,15 +161,6 @@ func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public B
 	}
 }
 
-func computeMACKeysSender(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
-	var macKeys []macKey
-	for _, receiver := range receivers {
-		macKey := computeMACKeySender(version, sender, ephemeralKey, receiver, headerHash)
-		macKeys = append(macKeys, macKey)
-	}
-	return macKeys
-}
-
 func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic BoxPublicKey, headerHash headerHash) macKey {
 	switch version {
 	case Version1():
@@ -182,6 +173,15 @@ func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic
 	default:
 		panic(fmt.Sprintf("Unknown version %+v", version))
 	}
+}
+
+func computeMACKeysSender(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
+	var macKeys []macKey
+	for _, receiver := range receivers {
+		macKey := computeMACKeySender(version, sender, ephemeralKey, receiver, headerHash)
+		macKeys = append(macKeys, macKey)
+	}
+	return macKeys
 }
 
 func computePayloadHash(headerHash headerHash, nonce Nonce, payloadCiphertext []byte) payloadHash {

--- a/common.go
+++ b/common.go
@@ -141,9 +141,7 @@ func computePayloadAuthenticator(macKey macKey, payloadHash payloadHash) payload
 	return sliceToByte32(fullMAC[:cryptoAuthBytes])
 }
 
-func computeMACKeySingle(secret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
-	// TODO: use V2 when needed.
-	nonce := nonceForMACKeyBoxV1(headerHash)
+func computeMACKeySingle(secret BoxSecretKey, public BoxPublicKey, nonce *Nonce) macKey {
 	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])
 }
@@ -161,10 +159,13 @@ func sum512Truncate256(in []byte) [32]byte {
 func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
 	switch version {
 	case Version1():
-		return computeMACKeySingle(secret, public, headerHash)
+		nonce := nonceForMACKeyBoxV1(headerHash)
+		return computeMACKeySingle(secret, public, nonce)
 	case Version2():
-		mac1 := computeMACKeySingle(secret, public, headerHash)
-		mac2 := computeMACKeySingle(eSecret, public, headerHash)
+		// TODO: Use v2.
+		nonce := nonceForMACKeyBoxV1(headerHash)
+		mac1 := computeMACKeySingle(secret, public, nonce)
+		mac2 := computeMACKeySingle(eSecret, public, nonce)
 		return sum512Truncate256(append(mac1[:], mac2[:]...))
 	default:
 		panic(ErrBadVersion{version})
@@ -174,10 +175,13 @@ func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public B
 func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic BoxPublicKey, headerHash headerHash) macKey {
 	switch version {
 	case Version1():
-		return computeMACKeySingle(secret, public, headerHash)
+		nonce := nonceForMACKeyBoxV1(headerHash)
+		return computeMACKeySingle(secret, public, nonce)
 	case Version2():
-		mac1 := computeMACKeySingle(secret, public, headerHash)
-		mac2 := computeMACKeySingle(secret, ePublic, headerHash)
+		// TODO: Use v2.
+		nonce := nonceForMACKeyBoxV1(headerHash)
+		mac1 := computeMACKeySingle(secret, public, nonce)
+		mac2 := computeMACKeySingle(secret, ePublic, nonce)
 		return sum512Truncate256(append(mac1[:], mac2[:]...))
 	default:
 		panic(ErrBadVersion{version})

--- a/common.go
+++ b/common.go
@@ -147,7 +147,7 @@ func computeMACKeySingle(secret BoxSecretKey, public BoxPublicKey, headerHash he
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])
 }
 
-func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
 	switch version {
 	case Version1():
 		return computeMACKeySingle(secret, public, headerHash)
@@ -161,10 +161,10 @@ func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPubl
 	}
 }
 
-func computeMACKeys(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
+func computeMACKeysSender(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
 	var macKeys []macKey
 	for _, receiver := range receivers {
-		macKey := computeMACKey(version, sender, ephemeralKey, receiver, headerHash)
+		macKey := computeMACKeySender(version, sender, ephemeralKey, receiver, headerHash)
 		macKeys = append(macKeys, macKey)
 	}
 	return macKeys

--- a/common.go
+++ b/common.go
@@ -154,8 +154,7 @@ func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public B
 	case Version2():
 		mac1 := computeMACKeySingle(secret, public, headerHash)
 		mac2 := computeMACKeySingle(eSecret, public, headerHash)
-		hash := sha512.Sum512_256(append(mac1[:], mac2[:]...))
-		return hash
+		return sha512.Sum512_256(append(mac1[:], mac2[:]...))
 	default:
 		panic(fmt.Sprintf("Unknown version %s", version))
 	}
@@ -168,8 +167,7 @@ func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic
 	case Version2():
 		mac1 := computeMACKeySingle(secret, public, headerHash)
 		mac2 := computeMACKeySingle(secret, ePublic, headerHash)
-		hash := sha512.Sum512_256(append(mac1[:], mac2[:]...))
-		return hash
+		return sha512.Sum512_256(append(mac1[:], mac2[:]...))
 	default:
 		panic(fmt.Sprintf("Unknown version %s", version))
 	}

--- a/common.go
+++ b/common.go
@@ -173,7 +173,7 @@ func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic
 	}
 }
 
-func computeMACKeysSender(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
+func computeMACKeysSender(version Version, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey, headerHash headerHash) []macKey {
 	var macKeys []macKey
 	for _, receiver := range receivers {
 		macKey := computeMACKeySender(version, sender, ephemeralKey, receiver, headerHash)

--- a/common.go
+++ b/common.go
@@ -162,8 +162,7 @@ func computeMACKeySender(version Version, index uint64, secret, eSecret BoxSecre
 		nonce := nonceForMACKeyBoxV1(headerHash)
 		return computeMACKeySingle(secret, public, nonce)
 	case Version2():
-		// TODO: Use v2.
-		nonce := nonceForMACKeyBoxV1(headerHash)
+		nonce := nonceForMACKeyBoxV2(headerHash, index)
 		mac1 := computeMACKeySingle(secret, public, nonce)
 		mac2 := computeMACKeySingle(eSecret, public, nonce)
 		return sum512Truncate256(append(mac1[:], mac2[:]...))
@@ -178,8 +177,7 @@ func computeMACKeyReceiver(version Version, index uint64, secret BoxSecretKey, p
 		nonce := nonceForMACKeyBoxV1(headerHash)
 		return computeMACKeySingle(secret, public, nonce)
 	case Version2():
-		// TODO: Use v2.
-		nonce := nonceForMACKeyBoxV1(headerHash)
+		nonce := nonceForMACKeyBoxV2(headerHash, index)
 		mac1 := computeMACKeySingle(secret, public, nonce)
 		mac2 := computeMACKeySingle(secret, ePublic, nonce)
 		return sum512Truncate256(append(mac1[:], mac2[:]...))

--- a/common.go
+++ b/common.go
@@ -151,9 +151,7 @@ func sum512Truncate256(in []byte) [32]byte {
 	// truncates SHA512 instead of calling SHA512/256, which has
 	// different IVs.
 	sum512 := sha512.Sum512(in)
-	var out [32]byte
-	copyEqualSize(out[:], sum512[:32])
-	return out
+	return sliceToByte32(sum512[:32])
 }
 
 func computeMACKeySender(version Version, index uint64, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {

--- a/common.go
+++ b/common.go
@@ -141,10 +141,21 @@ func computePayloadAuthenticator(macKey macKey, payloadHash payloadHash) payload
 	return sliceToByte32(fullMAC[:cryptoAuthBytes])
 }
 
-func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+func computeMACKeyHelper(secret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
 	nonce := nonceForMACKeyBox(headerHash)
 	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])
+}
+
+func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+	switch version {
+	case Version1():
+		return computeMACKeyHelper(secret, public, headerHash)
+	case Version2():
+		panic("Not implemented")
+	default:
+		panic(fmt.Sprintf("Unknown version %+v", version))
+	}
 }
 
 func computePayloadHash(headerHash headerHash, nonce Nonce, payloadCiphertext []byte) payloadHash {

--- a/common.go
+++ b/common.go
@@ -141,7 +141,7 @@ func computePayloadAuthenticator(macKey macKey, payloadHash payloadHash) payload
 	return sliceToByte32(fullMAC[:cryptoAuthBytes])
 }
 
-func computeMACKey(version Version, secret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
 	nonce := nonceForMACKeyBox(headerHash)
 	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])

--- a/common.go
+++ b/common.go
@@ -161,6 +161,15 @@ func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPubl
 	}
 }
 
+func computeMACKeys(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
+	var macKeys []macKey
+	for _, receiver := range receivers {
+		macKey := computeMACKey(version, sender, ephemeralKey, receiver, headerHash)
+		macKeys = append(macKeys, macKey)
+	}
+	return macKeys
+}
+
 func computePayloadHash(headerHash headerHash, nonce Nonce, payloadCiphertext []byte) payloadHash {
 	payloadDigest := sha512.New()
 	payloadDigest.Write(headerHash[:])

--- a/common.go
+++ b/common.go
@@ -156,7 +156,7 @@ func sum512Truncate256(in []byte) [32]byte {
 	return out
 }
 
-func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+func computeMACKeySender(version Version, index uint64, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
 	switch version {
 	case Version1():
 		nonce := nonceForMACKeyBoxV1(headerHash)
@@ -172,7 +172,7 @@ func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public B
 	}
 }
 
-func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic BoxPublicKey, headerHash headerHash) macKey {
+func computeMACKeyReceiver(version Version, index uint64, secret BoxSecretKey, public, ePublic BoxPublicKey, headerHash headerHash) macKey {
 	switch version {
 	case Version1():
 		nonce := nonceForMACKeyBoxV1(headerHash)
@@ -190,8 +190,8 @@ func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic
 
 func computeMACKeysSender(version Version, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey, headerHash headerHash) []macKey {
 	var macKeys []macKey
-	for _, receiver := range receivers {
-		macKey := computeMACKeySender(version, sender, ephemeralKey, receiver, headerHash)
+	for i, receiver := range receivers {
+		macKey := computeMACKeySender(version, uint64(i), sender, ephemeralKey, receiver, headerHash)
 		macKeys = append(macKeys, macKey)
 	}
 	return macKeys

--- a/common.go
+++ b/common.go
@@ -142,7 +142,8 @@ func computePayloadAuthenticator(macKey macKey, payloadHash payloadHash) payload
 }
 
 func computeMACKeySingle(secret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
-	nonce := nonceForMACKeyBox(headerHash)
+	// TODO: use V2 when needed.
+	nonce := nonceForMACKeyBoxV1(headerHash)
 	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])
 }

--- a/common.go
+++ b/common.go
@@ -152,7 +152,10 @@ func computeMACKey(version Version, secret, eSecret BoxSecretKey, public BoxPubl
 	case Version1():
 		return computeMACKeyHelper(secret, public, headerHash)
 	case Version2():
-		panic("Not implemented")
+		mac1 := computeMACKeyHelper(secret, public, headerHash)
+		mac2 := computeMACKeyHelper(eSecret, public, headerHash)
+		hash := sha512.Sum512_256(append(mac1[:], mac2[:]...))
+		return hash
 	default:
 		panic(fmt.Sprintf("Unknown version %+v", version))
 	}

--- a/common.go
+++ b/common.go
@@ -170,6 +170,20 @@ func computeMACKeys(version Version, headerHash headerHash, sender, ephemeralKey
 	return macKeys
 }
 
+func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic BoxPublicKey, headerHash headerHash) macKey {
+	switch version {
+	case Version1():
+		return computeMACKeyHelper(secret, public, headerHash)
+	case Version2():
+		mac1 := computeMACKeyHelper(secret, public, headerHash)
+		mac2 := computeMACKeyHelper(secret, ePublic, headerHash)
+		hash := sha512.Sum512_256(append(mac1[:], mac2[:]...))
+		return hash
+	default:
+		panic(fmt.Sprintf("Unknown version %+v", version))
+	}
+}
+
 func computePayloadHash(headerHash headerHash, nonce Nonce, payloadCiphertext []byte) payloadHash {
 	payloadDigest := sha512.New()
 	payloadDigest.Write(headerHash[:])

--- a/common.go
+++ b/common.go
@@ -141,7 +141,7 @@ func computePayloadAuthenticator(macKey macKey, payloadHash payloadHash) payload
 	return sliceToByte32(fullMAC[:cryptoAuthBytes])
 }
 
-func computeMACKeySingle(secret BoxSecretKey, public BoxPublicKey, nonce *Nonce) macKey {
+func computeMACKeySingle(secret BoxSecretKey, public BoxPublicKey, nonce Nonce) macKey {
 	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])
 }

--- a/common.go
+++ b/common.go
@@ -141,7 +141,7 @@ func computePayloadAuthenticator(macKey macKey, payloadHash payloadHash) payload
 	return sliceToByte32(fullMAC[:cryptoAuthBytes])
 }
 
-func computeMACKey(secret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+func computeMACKey(version Version, secret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
 	nonce := nonceForMACKeyBox(headerHash)
 	macKeyBox := secret.Box(public, nonce, make([]byte, cryptoAuthKeyBytes))
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])

--- a/common.go
+++ b/common.go
@@ -160,10 +160,11 @@ func computeMACKeySender(version Version, index uint64, secret, eSecret BoxSecre
 		nonce := nonceForMACKeyBoxV1(headerHash)
 		return computeMACKeySingle(secret, public, nonce)
 	case Version2():
-		nonce := nonceForMACKeyBoxV2(headerHash, index)
-		mac1 := computeMACKeySingle(secret, public, nonce)
-		mac2 := computeMACKeySingle(eSecret, public, nonce)
-		return sum512Truncate256(append(mac1[:], mac2[:]...))
+		nonce := nonceForMACKeyBoxV2(headerHash, false, index)
+		mac := computeMACKeySingle(secret, public, nonce)
+		eNonce := nonceForMACKeyBoxV2(headerHash, true, index)
+		eMAC := computeMACKeySingle(eSecret, public, eNonce)
+		return sum512Truncate256(append(mac[:], eMAC[:]...))
 	default:
 		panic(ErrBadVersion{version})
 	}
@@ -175,10 +176,11 @@ func computeMACKeyReceiver(version Version, index uint64, secret BoxSecretKey, p
 		nonce := nonceForMACKeyBoxV1(headerHash)
 		return computeMACKeySingle(secret, public, nonce)
 	case Version2():
-		nonce := nonceForMACKeyBoxV2(headerHash, index)
-		mac1 := computeMACKeySingle(secret, public, nonce)
-		mac2 := computeMACKeySingle(secret, ePublic, nonce)
-		return sum512Truncate256(append(mac1[:], mac2[:]...))
+		nonce := nonceForMACKeyBoxV2(headerHash, false, index)
+		mac := computeMACKeySingle(secret, public, nonce)
+		eNonce := nonceForMACKeyBoxV2(headerHash, true, index)
+		eMAC := computeMACKeySingle(secret, ePublic, eNonce)
+		return sum512Truncate256(append(mac[:], eMAC[:]...))
 	default:
 		panic(ErrBadVersion{version})
 	}

--- a/common.go
+++ b/common.go
@@ -157,7 +157,7 @@ func computeMACKeySender(version Version, secret, eSecret BoxSecretKey, public B
 		hash := sha512.Sum512_256(append(mac1[:], mac2[:]...))
 		return hash
 	default:
-		panic(fmt.Sprintf("Unknown version %+v", version))
+		panic(fmt.Sprintf("Unknown version %s", version))
 	}
 }
 
@@ -171,7 +171,7 @@ func computeMACKeyReceiver(version Version, secret BoxSecretKey, public, ePublic
 		hash := sha512.Sum512_256(append(mac1[:], mac2[:]...))
 		return hash
 	default:
-		panic(fmt.Sprintf("Unknown version %+v", version))
+		panic(fmt.Sprintf("Unknown version %s", version))
 	}
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -157,10 +157,13 @@ func TestComputeMACKeySendersSameRecipientV1(t *testing.T) {
 	receivers := []BoxPublicKey{public1, public1}
 	macKeys := computeMACKeysSender(Version1(), secret1, eSecret1, receivers, constHeaderHash)
 
-	firstMACKey := macKeys[0]
-	for i, macKey := range macKeys {
-		if macKey != firstMACKey {
-			t.Errorf("macKeys[%d] = %v != %v unexpectedly", i, macKey, firstMACKey)
-		}
+	if len(macKeys) != 2 {
+		t.Fatalf("len(macKeys)=%d != 2 unexpectedly", len(macKeys))
+	}
+
+	// Identical recipients lead to identical MAC keys in V1; this
+	// is vixed in V2.
+	if macKeys[0] != macKeys[1] {
+		t.Errorf("macKeys[0] = %v != macKeys[1] = %v unexpectedly", macKeys[0], macKeys[1])
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -180,3 +180,23 @@ func TestComputeMACKeySendersSameRecipientV2(t *testing.T) {
 		t.Errorf("macKeys[0] == macKeys[1] = %v unexpectedly", macKeys[0])
 	}
 }
+
+func testComputeMACKeySenderReceiver(t *testing.T, version Version) {
+	var index uint64 = 3
+	senderKey := newBoxKeyNoInsert(t)
+	eKey := newBoxKeyNoInsert(t)
+	receiverKey := newBoxKeyNoInsert(t)
+
+	senderMACKey := computeMACKeySender(version, index, senderKey, eKey, receiverKey.GetPublicKey(), constHeaderHash)
+	receiverMACKey := computeMACKeyReceiver(version, index, receiverKey, senderKey.GetPublicKey(), eKey.GetPublicKey(), constHeaderHash)
+	if senderMACKey != receiverMACKey {
+		t.Fatalf("senderMACKey = %v != receiverMACKey = %v", senderMACKey, receiverMACKey)
+	}
+}
+
+func TestCommon(t *testing.T) {
+	tests := []func(*testing.T, Version){
+		testComputeMACKeySenderReceiver,
+	}
+	runTestsOverVersions(t, "test", tests)
+}

--- a/common_test.go
+++ b/common_test.go
@@ -101,7 +101,7 @@ var public2 = boxPublicKey{
 
 var constHeaderHash = headerHash{0x7}
 
-func TestComputeMacKeySenderV1(t *testing.T) {
+func TestComputeMACKeySenderV1(t *testing.T) {
 	macKey1 := computeMACKeySender(Version1(), 0, secret1, eSecret1, public1, constHeaderHash)
 	macKey2 := computeMACKeySender(Version1(), 1, secret1, eSecret1, public1, constHeaderHash)
 	macKey3 := computeMACKeySender(Version1(), 0, secret2, eSecret1, public1, constHeaderHash)
@@ -129,7 +129,7 @@ func TestComputeMacKeySenderV1(t *testing.T) {
 	}
 }
 
-func TestComputeMacKeySenderV2(t *testing.T) {
+func TestComputeMACKeySenderV2(t *testing.T) {
 	macKey1 := computeMACKeySender(Version2(), 0, secret1, eSecret1, public1, constHeaderHash)
 	macKey2 := computeMACKeySender(Version2(), 1, secret1, eSecret1, public1, constHeaderHash)
 	macKey3 := computeMACKeySender(Version2(), 0, secret2, eSecret1, public1, constHeaderHash)
@@ -150,5 +150,17 @@ func TestComputeMacKeySenderV2(t *testing.T) {
 
 	if macKey5 == macKey1 {
 		t.Errorf("macKey5 == macKey1 == %v unexpectedly", macKey1)
+	}
+}
+
+func TestComputeMACKeySendersSameRecipientV1(t *testing.T) {
+	receivers := []BoxPublicKey{public1, public1}
+	macKeys := computeMACKeysSender(Version1(), secret1, eSecret1, receivers, constHeaderHash)
+
+	firstMACKey := macKeys[0]
+	for i, macKey := range macKeys {
+		if macKey != firstMACKey {
+			t.Errorf("macKeys[%d] = %v != %v unexpectedly", i, macKey, firstMACKey)
+		}
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -111,8 +111,29 @@ func TestComputeMacKeyV1(t *testing.T) {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)
 	}
 
+	// The V1 MAC key doesn't depend on the ephemeral keypair; this is
+	// fixed in V2.
 	if macKey3 != macKey1 {
 		t.Errorf("macKey3 == %v != macKey1 == %v unexpectedly", macKey3, macKey1)
+	}
+
+	if macKey4 == macKey1 {
+		t.Errorf("macKey4 == macKey1 == %v unexpectedly", macKey1)
+	}
+}
+
+func TestComputeMacKeyV2(t *testing.T) {
+	macKey1 := computeMACKeySender(Version2(), secret1, eSecret1, public1, constHeaderHash)
+	macKey2 := computeMACKeySender(Version2(), secret2, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKeySender(Version2(), secret1, eSecret2, public1, constHeaderHash)
+	macKey4 := computeMACKeySender(Version2(), secret1, eSecret1, public2, constHeaderHash)
+
+	if macKey2 == macKey1 {
+		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)
+	}
+
+	if macKey3 == macKey1 {
+		t.Errorf("macKey3 == macKey1 == %v unexpectedly", macKey1)
 	}
 
 	if macKey4 == macKey1 {

--- a/common_test.go
+++ b/common_test.go
@@ -103,22 +103,29 @@ var constHeaderHash = headerHash{0x7}
 
 func TestComputeMacKeySenderV1(t *testing.T) {
 	macKey1 := computeMACKeySender(Version1(), 0, secret1, eSecret1, public1, constHeaderHash)
-	macKey2 := computeMACKeySender(Version1(), 0, secret2, eSecret1, public1, constHeaderHash)
-	macKey3 := computeMACKeySender(Version1(), 0, secret1, eSecret2, public1, constHeaderHash)
-	macKey4 := computeMACKeySender(Version1(), 0, secret1, eSecret1, public2, constHeaderHash)
+	macKey2 := computeMACKeySender(Version1(), 1, secret1, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKeySender(Version1(), 0, secret2, eSecret1, public1, constHeaderHash)
+	macKey4 := computeMACKeySender(Version1(), 0, secret1, eSecret2, public1, constHeaderHash)
+	macKey5 := computeMACKeySender(Version1(), 0, secret1, eSecret1, public2, constHeaderHash)
 
-	if macKey2 == macKey1 {
-		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)
+	// The V1 MAC key doesn't depend on the index; this is fixed
+	// in V2.
+	if macKey2 != macKey1 {
+		t.Errorf("macKey2 == %v != macKey1 == %v unexpectedly", macKey2, macKey1)
+	}
+
+	if macKey3 == macKey1 {
+		t.Errorf("macKey3 == macKey1 == %v unexpectedly", macKey1)
 	}
 
 	// The V1 MAC key doesn't depend on the ephemeral keypair; this is
 	// fixed in V2.
-	if macKey3 != macKey1 {
-		t.Errorf("macKey3 == %v != macKey1 == %v unexpectedly", macKey3, macKey1)
+	if macKey4 != macKey1 {
+		t.Errorf("macKey4 == %v != macKey1 == %v unexpectedly", macKey4, macKey1)
 	}
 
-	if macKey4 == macKey1 {
-		t.Errorf("macKey4 == macKey1 == %v unexpectedly", macKey1)
+	if macKey5 == macKey1 {
+		t.Errorf("macKey5 == macKey1 == %v unexpectedly", macKey1)
 	}
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -102,10 +102,10 @@ var public2 = boxPublicKey{
 var constHeaderHash = headerHash{0x7}
 
 func TestComputeMacKeyV1(t *testing.T) {
-	macKey1 := computeMACKey(Version1(), secret1, eSecret1, public1, constHeaderHash)
-	macKey2 := computeMACKey(Version1(), secret2, eSecret1, public1, constHeaderHash)
-	macKey3 := computeMACKey(Version1(), secret1, eSecret2, public1, constHeaderHash)
-	macKey4 := computeMACKey(Version1(), secret1, eSecret1, public2, constHeaderHash)
+	macKey1 := computeMACKeySender(Version1(), secret1, eSecret1, public1, constHeaderHash)
+	macKey2 := computeMACKeySender(Version1(), secret2, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKeySender(Version1(), secret1, eSecret2, public1, constHeaderHash)
+	macKey4 := computeMACKeySender(Version1(), secret1, eSecret1, public2, constHeaderHash)
 
 	if macKey2 == macKey1 {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)

--- a/common_test.go
+++ b/common_test.go
@@ -162,8 +162,21 @@ func TestComputeMACKeySendersSameRecipientV1(t *testing.T) {
 	}
 
 	// Identical recipients lead to identical MAC keys in V1; this
-	// is vixed in V2.
+	// is fixed in V2.
 	if macKeys[0] != macKeys[1] {
 		t.Errorf("macKeys[0] = %v != macKeys[1] = %v unexpectedly", macKeys[0], macKeys[1])
+	}
+}
+
+func TestComputeMACKeySendersSameRecipientV2(t *testing.T) {
+	receivers := []BoxPublicKey{public1, public1}
+	macKeys := computeMACKeysSender(Version2(), secret1, eSecret1, receivers, constHeaderHash)
+
+	if len(macKeys) != 2 {
+		t.Fatalf("len(macKeys)=%d != 2 unexpectedly", len(macKeys))
+	}
+
+	if macKeys[0] == macKeys[1] {
+		t.Errorf("macKeys[0] == macKeys[1] = %v unexpectedly", macKeys[0])
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -85,6 +85,10 @@ var secret2 = boxSecretKey{
 	key: RawBoxKey{0x10},
 }
 
+var eSecret = boxSecretKey{
+	key: RawBoxKey{0x28},
+}
+
 var public1 = boxPublicKey{
 	key: RawBoxKey{0x5},
 }
@@ -95,9 +99,9 @@ var public2 = boxPublicKey{
 var constHeaderHash = headerHash{0x7}
 
 func TestComputeMacKey(t *testing.T) {
-	macKey1 := computeMACKey(secret1, public1, constHeaderHash)
-	macKey2 := computeMACKey(secret2, public1, constHeaderHash)
-	macKey3 := computeMACKey(secret1, public2, constHeaderHash)
+	macKey1 := computeMACKey(Version1(), secret1, eSecret, public1, constHeaderHash)
+	macKey2 := computeMACKey(Version1(), secret2, eSecret, public1, constHeaderHash)
+	macKey3 := computeMACKey(Version1(), secret1, eSecret, public2, constHeaderHash)
 
 	if macKey2 == macKey1 {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)

--- a/common_test.go
+++ b/common_test.go
@@ -131,9 +131,10 @@ func TestComputeMacKeySenderV1(t *testing.T) {
 
 func TestComputeMacKeySenderV2(t *testing.T) {
 	macKey1 := computeMACKeySender(Version2(), 0, secret1, eSecret1, public1, constHeaderHash)
-	macKey2 := computeMACKeySender(Version2(), 0, secret2, eSecret1, public1, constHeaderHash)
-	macKey3 := computeMACKeySender(Version2(), 0, secret1, eSecret2, public1, constHeaderHash)
-	macKey4 := computeMACKeySender(Version2(), 0, secret1, eSecret1, public2, constHeaderHash)
+	macKey2 := computeMACKeySender(Version2(), 1, secret1, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKeySender(Version2(), 0, secret2, eSecret1, public1, constHeaderHash)
+	macKey4 := computeMACKeySender(Version2(), 0, secret1, eSecret2, public1, constHeaderHash)
+	macKey5 := computeMACKeySender(Version2(), 0, secret1, eSecret1, public2, constHeaderHash)
 
 	if macKey2 == macKey1 {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)
@@ -145,5 +146,9 @@ func TestComputeMacKeySenderV2(t *testing.T) {
 
 	if macKey4 == macKey1 {
 		t.Errorf("macKey4 == macKey1 == %v unexpectedly", macKey1)
+	}
+
+	if macKey5 == macKey1 {
+		t.Errorf("macKey5 == macKey1 == %v unexpectedly", macKey1)
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -101,7 +101,7 @@ var public2 = boxPublicKey{
 
 var constHeaderHash = headerHash{0x7}
 
-func TestComputeMacKeyV1(t *testing.T) {
+func TestComputeMacKeySenderV1(t *testing.T) {
 	macKey1 := computeMACKeySender(Version1(), secret1, eSecret1, public1, constHeaderHash)
 	macKey2 := computeMACKeySender(Version1(), secret2, eSecret1, public1, constHeaderHash)
 	macKey3 := computeMACKeySender(Version1(), secret1, eSecret2, public1, constHeaderHash)
@@ -122,7 +122,7 @@ func TestComputeMacKeyV1(t *testing.T) {
 	}
 }
 
-func TestComputeMacKeyV2(t *testing.T) {
+func TestComputeMacKeySenderV2(t *testing.T) {
 	macKey1 := computeMACKeySender(Version2(), secret1, eSecret1, public1, constHeaderHash)
 	macKey2 := computeMACKeySender(Version2(), secret2, eSecret1, public1, constHeaderHash)
 	macKey3 := computeMACKeySender(Version2(), secret1, eSecret2, public1, constHeaderHash)

--- a/common_test.go
+++ b/common_test.go
@@ -85,8 +85,11 @@ var secret2 = boxSecretKey{
 	key: RawBoxKey{0x10},
 }
 
-var eSecret = boxSecretKey{
-	key: RawBoxKey{0x28},
+var eSecret1 = boxSecretKey{
+	key: RawBoxKey{0x18},
+}
+var eSecret2 = boxSecretKey{
+	key: RawBoxKey{0x20},
 }
 
 var public1 = boxPublicKey{
@@ -98,16 +101,21 @@ var public2 = boxPublicKey{
 
 var constHeaderHash = headerHash{0x7}
 
-func TestComputeMacKey(t *testing.T) {
-	macKey1 := computeMACKey(Version1(), secret1, eSecret, public1, constHeaderHash)
-	macKey2 := computeMACKey(Version1(), secret2, eSecret, public1, constHeaderHash)
-	macKey3 := computeMACKey(Version1(), secret1, eSecret, public2, constHeaderHash)
+func TestComputeMacKeyV1(t *testing.T) {
+	macKey1 := computeMACKey(Version1(), secret1, eSecret1, public1, constHeaderHash)
+	macKey2 := computeMACKey(Version1(), secret2, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKey(Version1(), secret1, eSecret2, public1, constHeaderHash)
+	macKey4 := computeMACKey(Version1(), secret1, eSecret1, public2, constHeaderHash)
 
 	if macKey2 == macKey1 {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)
 	}
 
-	if macKey3 == macKey1 {
-		t.Errorf("macKey3 == macKey1 == %v unexpectedly", macKey1)
+	if macKey3 != macKey1 {
+		t.Errorf("macKey3 == %v != macKey1 == %v unexpectedly", macKey3, macKey1)
+	}
+
+	if macKey4 == macKey1 {
+		t.Errorf("macKey4 == macKey1 == %v unexpectedly", macKey1)
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -102,10 +102,10 @@ var public2 = boxPublicKey{
 var constHeaderHash = headerHash{0x7}
 
 func TestComputeMacKeySenderV1(t *testing.T) {
-	macKey1 := computeMACKeySender(Version1(), secret1, eSecret1, public1, constHeaderHash)
-	macKey2 := computeMACKeySender(Version1(), secret2, eSecret1, public1, constHeaderHash)
-	macKey3 := computeMACKeySender(Version1(), secret1, eSecret2, public1, constHeaderHash)
-	macKey4 := computeMACKeySender(Version1(), secret1, eSecret1, public2, constHeaderHash)
+	macKey1 := computeMACKeySender(Version1(), 0, secret1, eSecret1, public1, constHeaderHash)
+	macKey2 := computeMACKeySender(Version1(), 0, secret2, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKeySender(Version1(), 0, secret1, eSecret2, public1, constHeaderHash)
+	macKey4 := computeMACKeySender(Version1(), 0, secret1, eSecret1, public2, constHeaderHash)
 
 	if macKey2 == macKey1 {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)
@@ -123,10 +123,10 @@ func TestComputeMacKeySenderV1(t *testing.T) {
 }
 
 func TestComputeMacKeySenderV2(t *testing.T) {
-	macKey1 := computeMACKeySender(Version2(), secret1, eSecret1, public1, constHeaderHash)
-	macKey2 := computeMACKeySender(Version2(), secret2, eSecret1, public1, constHeaderHash)
-	macKey3 := computeMACKeySender(Version2(), secret1, eSecret2, public1, constHeaderHash)
-	macKey4 := computeMACKeySender(Version2(), secret1, eSecret1, public2, constHeaderHash)
+	macKey1 := computeMACKeySender(Version2(), 0, secret1, eSecret1, public1, constHeaderHash)
+	macKey2 := computeMACKeySender(Version2(), 0, secret2, eSecret1, public1, constHeaderHash)
+	macKey3 := computeMACKeySender(Version2(), 0, secret1, eSecret2, public1, constHeaderHash)
+	macKey4 := computeMACKeySender(Version2(), 0, secret1, eSecret1, public2, constHeaderHash)
 
 	if macKey2 == macKey1 {
 		t.Errorf("macKey2 == macKey1 == %v unexpectedly", macKey1)

--- a/decrypt.go
+++ b/decrypt.go
@@ -263,7 +263,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	}
 
 	// Compute the MAC key.
-	ds.macKey = computeMACKeyReceiver(hdr.Version, secretKey, ds.mki.SenderKey, ephemeralKey, ds.headerHash)
+	ds.macKey = computeMACKeyReceiver(hdr.Version, uint64(ds.position), secretKey, ds.mki.SenderKey, ephemeralKey, ds.headerHash)
 
 	return nil
 }

--- a/decrypt.go
+++ b/decrypt.go
@@ -264,7 +264,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 
 	// Compute the MAC key.
 	// TODO: Plumb down correct version.
-	ds.macKey = computeMACKey(Version1, secretKey, nil, ds.mki.SenderKey, ds.headerHash)
+	ds.macKey = computeMACKey(Version1(), secretKey, nil, ds.mki.SenderKey, ds.headerHash)
 
 	return nil
 }

--- a/decrypt.go
+++ b/decrypt.go
@@ -263,7 +263,8 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	}
 
 	// Compute the MAC key.
-	ds.macKey = computeMACKey(secretKey, ds.mki.SenderKey, ds.headerHash)
+	// TODO: Plumb down correct version.
+	ds.macKey = computeMACKey(Version1, secretKey, ds.mki.SenderKey, ds.headerHash)
 
 	return nil
 }

--- a/decrypt.go
+++ b/decrypt.go
@@ -263,8 +263,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	}
 
 	// Compute the MAC key.
-	// TODO: Plumb down correct version.
-	ds.macKey = computeMACKey(Version1(), secretKey, nil, ds.mki.SenderKey, ds.headerHash)
+	ds.macKey = computeMACKeyReceiver(hdr.Version, secretKey, ds.mki.SenderKey, ephemeralKey, ds.headerHash)
 
 	return nil
 }

--- a/decrypt.go
+++ b/decrypt.go
@@ -264,7 +264,7 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 
 	// Compute the MAC key.
 	// TODO: Plumb down correct version.
-	ds.macKey = computeMACKey(Version1, secretKey, ds.mki.SenderKey, ds.headerHash)
+	ds.macKey = computeMACKey(Version1, secretKey, nil, ds.mki.SenderKey, ds.headerHash)
 
 	return nil
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -193,16 +193,18 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	}
 
 	// Use the header hash to compute the MAC keys.
-	es.computeMACKeys(sender, receivers)
+	es.macKeys = computeMACKeys(es.header.Version, es.headerHash, sender, receivers)
 
 	return nil
 }
 
-func (es *encryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
+func computeMACKeys(version Version, headerHash []byte, sender BoxSecretKey, receivers []BoxPublicKey) [][]byte {
+	var macKeys [][]byte
 	for _, receiver := range receivers {
-		macKey := computeMACKey(es.header.Version, sender, receiver, es.headerHash)
-		es.macKeys = append(es.macKeys, macKey)
+		macKey := computeMACKey(version, sender, receiver, headerHash)
+		macKeys = append(macKeys, macKey)
 	}
+	return macKeys
 }
 
 func (es *encryptStream) Close() error {

--- a/encrypt.go
+++ b/encrypt.go
@@ -198,15 +198,6 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	return nil
 }
 
-func computeMACKeys(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
-	var macKeys []macKey
-	for _, receiver := range receivers {
-		macKey := computeMACKey(version, sender, ephemeralKey, receiver, headerHash)
-		macKeys = append(macKeys, macKey)
-	}
-	return macKeys
-}
-
 func (es *encryptStream) Close() error {
 	for es.buffer.Len() > 0 {
 		err := es.encryptBlock()

--- a/encrypt.go
+++ b/encrypt.go
@@ -134,7 +134,7 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 		return err
 	}
 
-	if version != Version1 && version != Version2 {
+	if version != Version1() && version != Version2() {
 		return fmt.Errorf("Unknown version %+v", version)
 	}
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -164,7 +164,8 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	eh.SenderSecretbox = secretbox.Seal([]byte{}, sender.GetPublicKey().ToKID(), (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
 	for _, receiver := range receivers {
-		payloadKeyBox := ephemeralKey.Box(receiver, nonceForPayloadKeyBoxV1(), es.payloadKey[:])
+		sharedKey := ephemeralKey.Precompute(receiver)
+		payloadKeyBox := sharedKey.Box(nonceForPayloadKeyBoxV1(), es.payloadKey[:])
 
 		keys := receiverKeys{PayloadKeyBox: payloadKeyBox}
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -188,7 +188,10 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	}
 
 	// Use the header hash to compute the MAC keys.
-	es.macKeys = computeMACKeys(es.header.Version, es.headerHash, sender, ephemeralKey, receivers)
+	//
+	// TODO: Pre-compute the shared key in the receiver loop above
+	// and pass it through to computeMACKeysSender.
+	es.macKeys = computeMACKeysSender(es.header.Version, es.headerHash, sender, ephemeralKey, receivers)
 
 	return nil
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
-	"fmt"
 	"io"
 
 	"golang.org/x/crypto/nacl/secretbox"
@@ -132,10 +131,6 @@ func checkKnownVersion(version Version) error {
 func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []BoxPublicKey) error {
 	if err := checkKnownVersion(version); err != nil {
 		return err
-	}
-
-	if version != Version1() && version != Version2() {
-		return fmt.Errorf("Unknown version %+v", version)
 	}
 
 	if err := es.checkReceivers(receivers); err != nil {

--- a/encrypt.go
+++ b/encrypt.go
@@ -200,7 +200,7 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 
 func (es *encryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
 	for _, receiver := range receivers {
-		macKey := computeMACKey(sender, receiver, es.headerHash)
+		macKey := computeMACKey(es.header.Version, sender, receiver, es.headerHash)
 		es.macKeys = append(es.macKeys, macKey)
 	}
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
+	"fmt"
 	"io"
 
 	"golang.org/x/crypto/nacl/secretbox"
@@ -131,6 +132,10 @@ func checkKnownVersion(version Version) error {
 func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []BoxPublicKey) error {
 	if err := checkKnownVersion(version); err != nil {
 		return err
+	}
+
+	if version != Version1 && version != Version2 {
+		return fmt.Errorf("Unknown version %+v", version)
 	}
 
 	if err := es.checkReceivers(receivers); err != nil {

--- a/encrypt.go
+++ b/encrypt.go
@@ -191,7 +191,7 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	//
 	// TODO: Pre-compute the shared key in the receiver loop above
 	// and pass it through to computeMACKeysSender.
-	es.macKeys = computeMACKeysSender(es.header.Version, es.headerHash, sender, ephemeralKey, receivers)
+	es.macKeys = computeMACKeysSender(es.header.Version, sender, ephemeralKey, receivers, es.headerHash)
 
 	return nil
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -189,8 +189,8 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 
 	// Use the header hash to compute the MAC keys.
 	//
-	// TODO: Pre-compute the shared key in the receiver loop above
-	// and pass it through to computeMACKeysSender.
+	// TODO: Plumb the pre-computed shared keys above through to
+	// computeMACKeysSender.
 	es.macKeys = computeMACKeysSender(es.header.Version, sender, ephemeralKey, receivers, es.headerHash)
 
 	return nil

--- a/encrypt.go
+++ b/encrypt.go
@@ -193,15 +193,15 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	}
 
 	// Use the header hash to compute the MAC keys.
-	es.macKeys = computeMACKeys(es.header.Version, es.headerHash, sender, receivers)
+	es.macKeys = computeMACKeys(es.header.Version, es.headerHash, sender, ephemeralKey, receivers)
 
 	return nil
 }
 
-func computeMACKeys(version Version, headerHash []byte, sender BoxSecretKey, receivers []BoxPublicKey) [][]byte {
-	var macKeys [][]byte
+func computeMACKeys(version Version, headerHash headerHash, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey) []macKey {
+	var macKeys []macKey
 	for _, receiver := range receivers {
-		macKey := computeMACKey(version, sender, receiver, headerHash)
+		macKey := computeMACKey(version, sender, ephemeralKey, receiver, headerHash)
 		macKeys = append(macKeys, macKey)
 	}
 	return macKeys

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -134,9 +134,9 @@ func (b boxSecretKey) GetPublicKey() BoxPublicKey {
 
 type boxPrecomputedSharedKey RawBoxKey
 
-func (b boxSecretKey) Precompute(pk BoxPublicKey) BoxPrecomputedSharedKey {
+func (b boxSecretKey) Precompute(peer BoxPublicKey) BoxPrecomputedSharedKey {
 	var res boxPrecomputedSharedKey
-	box.Precompute((*[32]byte)(&res), (*[32]byte)(pk.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
+	box.Precompute((*[32]byte)(&res), (*[32]byte)(peer.ToRawBoxKeyPointer()), (*[32]byte)(&b.key))
 	return res
 }
 

--- a/errors.go
+++ b/errors.go
@@ -111,7 +111,7 @@ func (e ErrWrongMessageType) Error() string {
 	return fmt.Sprintf("Wrong saltpack message type: wanted %s, but got %s instead", e.wanted, e.received)
 }
 func (e ErrBadVersion) Error() string {
-	return fmt.Sprintf("Unsupported version (%v)", e.received)
+	return fmt.Sprintf("Unsupported version (%s)", e.received)
 }
 func (e ErrBadCiphertext) Error() string {
 	return fmt.Sprintf("In packet %d: bad ciphertext; failed Poly1305", e)

--- a/key.go
+++ b/key.go
@@ -80,7 +80,7 @@ type BoxSecretKey interface {
 	GetPublicKey() BoxPublicKey
 
 	// Precompute computes a DH with the given key
-	Precompute(sender BoxPublicKey) BoxPrecomputedSharedKey
+	Precompute(peer BoxPublicKey) BoxPrecomputedSharedKey
 }
 
 // SigningSecretKey is a secret NaCl key that can sign messages.

--- a/nonce.go
+++ b/nonce.go
@@ -34,13 +34,14 @@ func nonceForMACKeyBoxV1(headerHash headerHash) Nonce {
 
 func nonceForMACKeyBoxV2(headerHash headerHash, ephemeral bool, recip uint64) Nonce {
 	var n Nonce
-	copyEqualSize(n[:len(n)-8], headerHash[:len(n)-8])
-	// Set high bit based on ephemeral.
-	n[0] &^= (1 << 7)
+	off := len(n) - 8
+	copyEqualSize(n[:off], headerHash[:off])
+	// Set LSB of last byte based on ephemeral.
+	n[off-1] &^= 1
 	if ephemeral {
-		n[0] |= (1 << 7)
+		n[off-1] |= 1
 	}
-	binary.BigEndian.PutUint64(n[len(n)-8:], uint64(recip))
+	binary.BigEndian.PutUint64(n[off:], uint64(recip))
 	return n
 }
 

--- a/nonce.go
+++ b/nonce.go
@@ -35,6 +35,11 @@ func nonceForMACKeyBoxV1(headerHash headerHash) Nonce {
 func nonceForMACKeyBoxV2(headerHash headerHash, ephemeral bool, recip uint64) Nonce {
 	var n Nonce
 	copyEqualSize(n[:len(n)-8], headerHash[:len(n)-8])
+	// Set high bit based on ephemeral.
+	n[0] &^= (1 << 7)
+	if ephemeral {
+		n[0] |= (1 << 7)
+	}
 	binary.BigEndian.PutUint64(n[len(n)-8:], uint64(recip))
 	return n
 }

--- a/nonce.go
+++ b/nonce.go
@@ -20,6 +20,7 @@ func nonceForPayloadKeyBoxV1() Nonce {
 }
 
 func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
+	// TODO: Actually mix in recip.
 	return stringToByte24("saltpack_recipsbXXXXXXXX")
 }
 
@@ -27,8 +28,15 @@ func nonceForDerivedSharedKey() Nonce {
 	return stringToByte24("saltpack_derived_sboxkey")
 }
 
-func nonceForMACKeyBox(headerHash headerHash) Nonce {
+func nonceForMACKeyBoxV1(headerHash headerHash) Nonce {
 	return sliceToByte24(headerHash[:nonceBytes])
+}
+
+func nonceForMACKeyBoxV2(headerHash headerHash, recip uint64) Nonce {
+	var n Nonce
+	copyEqualSize(n[:nonceBytes-8], headerHash[:nonceBytes-8])
+	binary.BigEndian.PutUint64(n[nonceBytes-8:], uint64(recip))
+	return n
 }
 
 // Construct the nonce for the ith block of payload.

--- a/nonce.go
+++ b/nonce.go
@@ -34,8 +34,8 @@ func nonceForMACKeyBoxV1(headerHash headerHash) Nonce {
 
 func nonceForMACKeyBoxV2(headerHash headerHash, recip uint64) Nonce {
 	var n Nonce
-	copyEqualSize(n[:nonceBytes-8], headerHash[:nonceBytes-8])
-	binary.BigEndian.PutUint64(n[nonceBytes-8:], uint64(recip))
+	copyEqualSize(n[:len(n)-8], headerHash[:len(n)-8])
+	binary.BigEndian.PutUint64(n[len(n)-8:], uint64(recip))
 	return n
 }
 

--- a/nonce.go
+++ b/nonce.go
@@ -32,7 +32,7 @@ func nonceForMACKeyBoxV1(headerHash headerHash) Nonce {
 	return sliceToByte24(headerHash[:nonceBytes])
 }
 
-func nonceForMACKeyBoxV2(headerHash headerHash, recip uint64) Nonce {
+func nonceForMACKeyBoxV2(headerHash headerHash, ephemeral bool, recip uint64) Nonce {
 	var n Nonce
 	copyEqualSize(n[:len(n)-8], headerHash[:len(n)-8])
 	binary.BigEndian.PutUint64(n[len(n)-8:], uint64(recip))

--- a/nonce_test.go
+++ b/nonce_test.go
@@ -1,0 +1,25 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"testing"
+)
+
+func TestNonceForMACKeyBoxV2(t *testing.T) {
+	hash1 := headerHash{0x01}
+	hash2 := headerHash{0x02}
+
+	nonce1 := nonceForMACKeyBoxV2(hash1, 0)
+	nonce2 := nonceForMACKeyBoxV2(hash2, 0)
+	nonce3 := nonceForMACKeyBoxV2(hash1, 1)
+
+	if *nonce2 == *nonce1 {
+		t.Errorf("*nonce2 == *nonce1 == %v unexpectedly", *nonce1)
+	}
+
+	if *nonce3 == *nonce1 {
+		t.Errorf("*nonce3 == *nonce1 == %v unexpectedly", *nonce1)
+	}
+}

--- a/nonce_test.go
+++ b/nonce_test.go
@@ -11,15 +11,20 @@ func TestNonceForMACKeyBoxV2(t *testing.T) {
 	hash1 := headerHash{0x01}
 	hash2 := headerHash{0x02}
 
-	nonce1 := nonceForMACKeyBoxV2(hash1, 0)
-	nonce2 := nonceForMACKeyBoxV2(hash2, 0)
-	nonce3 := nonceForMACKeyBoxV2(hash1, 1)
+	nonce1 := nonceForMACKeyBoxV2(hash1, false, 0)
+	nonce2 := nonceForMACKeyBoxV2(hash2, false, 0)
+	nonce3 := nonceForMACKeyBoxV2(hash1, true, 0)
+	nonce4 := nonceForMACKeyBoxV2(hash1, false, 1)
 
-	if *nonce2 == *nonce1 {
-		t.Errorf("*nonce2 == *nonce1 == %v unexpectedly", *nonce1)
+	if nonce2 == nonce1 {
+		t.Errorf("nonce2 == nonce1 == %v unexpectedly", nonce1)
 	}
 
-	if *nonce3 == *nonce1 {
-		t.Errorf("*nonce3 == *nonce1 == %v unexpectedly", *nonce1)
+	if nonce3 == nonce1 {
+		t.Errorf("nonce3 == nonce1 == %v unexpectedly", nonce1)
+	}
+
+	if nonce4 == nonce1 {
+		t.Errorf("nonce4 == nonce1 == %v unexpectedly", nonce1)
 	}
 }

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -213,7 +213,7 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 	}
 
 	// Use the header hash to compute the MAC keys.
-	pes.macKeys = computeMACKeysSender(pes.header.Version, pes.headerHash, sender, ephemeralKey, receivers)
+	pes.macKeys = computeMACKeysSender(pes.header.Version, sender, ephemeralKey, receivers, pes.headerHash)
 
 	return nil
 }

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -213,7 +213,7 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 	}
 
 	// Use the header hash to compute the MAC keys.
-	pes.macKeys = computeMACKeys(pes.header.Version, pes.headerHash, sender, ephemeralKey, receivers)
+	pes.macKeys = computeMACKeysSender(pes.header.Version, pes.headerHash, sender, ephemeralKey, receivers)
 
 	return nil
 }

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -218,7 +218,7 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 func (pes *testEncryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
 	for _, receiver := range receivers {
 		// TODO: Plumb down version.
-		macKey := computeMACKey(Version1, sender, nil, receiver, pes.headerHash)
+		macKey := computeMACKey(Version1(), sender, nil, receiver, pes.headerHash)
 		pes.macKeys = append(pes.macKeys, macKey)
 	}
 }

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -191,12 +191,15 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 		eh.Receivers = append(eh.Receivers, keys)
 	}
 
+	// Corrupt a copy so that the corruption doesn't cause
+	// e.g. computeMACKeys to panic.
+	ehMaybeCorrupt := *eh
 	if pes.options.corruptHeader != nil {
-		pes.options.corruptHeader(eh)
+		pes.options.corruptHeader(&ehMaybeCorrupt)
 	}
 
 	// Encode the header and the header length, and write them out immediately.
-	headerBytes, err := encodeToBytes(pes.header)
+	headerBytes, err := encodeToBytes(ehMaybeCorrupt)
 	if err != nil {
 		return err
 	}

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -218,7 +218,7 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 func (pes *testEncryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
 	for _, receiver := range receivers {
 		// TODO: Plumb down version.
-		macKey := computeMACKey(Version1, sender, receiver, pes.headerHash)
+		macKey := computeMACKey(Version1, sender, nil, receiver, pes.headerHash)
 		pes.macKeys = append(pes.macKeys, macKey)
 	}
 }

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -210,17 +210,9 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 	}
 
 	// Use the header hash to compute the MAC keys.
-	pes.computeMACKeys(sender, receivers)
+	pes.macKeys = computeMACKeys(pes.header.Version, pes.headerHash, sender, ephemeralKey, receivers)
 
 	return nil
-}
-
-func (pes *testEncryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
-	for _, receiver := range receivers {
-		// TODO: Plumb down version.
-		macKey := computeMACKey(Version1(), sender, nil, receiver, pes.headerHash)
-		pes.macKeys = append(pes.macKeys, macKey)
-	}
 }
 
 func (pes *testEncryptStream) Close() error {

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -217,7 +217,8 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 
 func (pes *testEncryptStream) computeMACKeys(sender BoxSecretKey, receivers []BoxPublicKey) {
 	for _, receiver := range receivers {
-		macKey := computeMACKey(sender, receiver, pes.headerHash)
+		// TODO: Plumb down version.
+		macKey := computeMACKey(Version1, sender, receiver, pes.headerHash)
 		pes.macKeys = append(pes.macKeys, macKey)
 	}
 }


### PR DESCRIPTION
Also mix in index into MAC nonce.

This prevents tampering of previously produced message ciphertexts,
even if the sender's private key is compromised.