### PR TITLE
Remove Saltpack prefixes from some consts and vars

### DIFF
--- a/armor_test.go
+++ b/armor_test.go
@@ -44,7 +44,7 @@ func testArmor(t *testing.T, sz int) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(m, m2) {
-		t.Errorf("Buffers disagreed: %v != %v (%d v %d)\n", m, m2, len(m), len(m2))
+		t.Errorf("Buffers disagreed: %v != %v (%d v %d)", m, m2, len(m), len(m2))
 	}
 	if hdr != hdr2 {
 		t.Errorf("headers disagreed: %s != %s", hdr, hdr2)

--- a/const.go
+++ b/const.go
@@ -44,9 +44,9 @@ const SignedArmorString = "SIGNED MESSAGE"
 // DetachedSignatureArmorString is included in armor headers for detached signatures.
 const DetachedSignatureArmorString = "DETACHED SIGNATURE"
 
-// SaltpackFormatName is the publicly advertised name of the format,
-// used in the header of the message and also in Nonce creation.
-const SaltpackFormatName = "saltpack"
+// FormatName is the publicly advertised name of the format, used in
+// the header of the message and also in Nonce creation.
+const FormatName = "saltpack"
 
 // signatureBlockSize is by default 1MB and can't currently be tweaked.
 const signatureBlockSize int = 1048576

--- a/const.go
+++ b/const.go
@@ -28,9 +28,9 @@ const MessageTypeDetachedSignature MessageType = 2
 // signcrypted message.
 const MessageTypeSigncryption MessageType = 3
 
-var SaltpackVersion1 = Version{Major: 1, Minor: 0}
-var SaltpackVersion2 = Version{Major: 2, Minor: 0}
-var SaltpackCurrentVersion = SaltpackVersion1
+var Version1 = Version{Major: 1, Minor: 0}
+var Version2 = Version{Major: 2, Minor: 0}
+var CurrentVersion = Version1
 
 // encryptionBlockSize is by default 1MB and can't currently be tweaked.
 const encryptionBlockSize int = 1048576

--- a/const.go
+++ b/const.go
@@ -28,9 +28,16 @@ const MessageTypeDetachedSignature MessageType = 2
 // signcrypted message.
 const MessageTypeSigncryption MessageType = 3
 
-var Version1 = Version{Major: 1, Minor: 0}
-var Version2 = Version{Major: 2, Minor: 0}
-var CurrentVersion = Version1
+func Version1() Version {
+	return Version{Major: 1, Minor: 0}
+}
+func Version2() Version {
+	return Version{Major: 2, Minor: 0}
+}
+
+func CurrentVersion() Version {
+	return Version1()
+}
 
 // encryptionBlockSize is by default 1MB and can't currently be tweaked.
 const encryptionBlockSize int = 1048576

--- a/decrypt.go
+++ b/decrypt.go
@@ -323,7 +323,7 @@ func NewDecryptStream(r io.Reader, keyring Keyring) (mki *MessageKeyInfo, plaint
 }
 
 // Open simply opens a ciphertext given the set of keys in the specified keyring.
-// It returns a plaintext on sucess, and an error on failure. It returns the header's
+// It returns a plaintext on success, and an error on failure. It returns the header's
 // MessageKeyInfo in either case.
 func Open(ciphertext []byte, keyring Keyring) (i *MessageKeyInfo, plaintext []byte, err error) {
 	buf := bytes.NewBuffer(ciphertext)

--- a/encrypt.go
+++ b/encrypt.go
@@ -138,7 +138,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 
 	eh := &EncryptionHeader{
 		FormatName: FormatName,
-		Version:    SaltpackCurrentVersion,
+		Version:    CurrentVersion,
 		Type:       MessageTypeEncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 		Receivers:  make([]receiverKeys, 0, len(receivers)),

--- a/encrypt.go
+++ b/encrypt.go
@@ -138,7 +138,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 
 	eh := &EncryptionHeader{
 		FormatName: FormatName,
-		Version:    CurrentVersion,
+		Version:    CurrentVersion(),
 		Type:       MessageTypeEncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 		Receivers:  make([]receiverKeys, 0, len(receivers)),

--- a/encrypt.go
+++ b/encrypt.go
@@ -137,7 +137,7 @@ func (es *encryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey) err
 	}
 
 	eh := &EncryptionHeader{
-		FormatName: SaltpackFormatName,
+		FormatName: FormatName,
 		Version:    SaltpackCurrentVersion,
 		Type:       MessageTypeEncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -448,7 +448,7 @@ func TestTruncation(t *testing.T) {
 	trunced1 := ciphertext[0 : len(ciphertext)-51]
 	_, _, err = Open(trunced1, kr)
 	if err != io.ErrUnexpectedEOF {
-		t.Fatalf("Wanted an %v; but got %v\n", io.ErrUnexpectedEOF, err)
+		t.Fatalf("Wanted an %v; but got %v", io.ErrUnexpectedEOF, err)
 	}
 }
 
@@ -544,7 +544,7 @@ func TestEmptyReceivers(t *testing.T) {
 	plaintext := randomMsg(t, 1024*3)
 	_, err := Seal(plaintext, sender, receivers)
 	if err != ErrBadReceivers {
-		t.Fatalf("Wanted error %v but got %v\n", ErrBadReceivers, err)
+		t.Fatalf("Wanted error %v but got %v", ErrBadReceivers, err)
 	}
 }
 

--- a/frame.go
+++ b/frame.go
@@ -37,7 +37,7 @@ func makeFrame(which headerOrFooterMarker, typ MessageType, brand string) string
 		words = append(words, brand)
 		brand += " "
 	}
-	words = append(words, strings.ToUpper(SaltpackFormatName))
+	words = append(words, strings.ToUpper(FormatName))
 	words = append(words, sffx)
 	return strings.Join(words, " ")
 }
@@ -97,7 +97,7 @@ func parseFrame(m string, typ MessageType, hof headerOrFooterMarker) (brand stri
 		return
 	}
 	spfn := pop(&v, 1)
-	if spfn[0] != strings.ToUpper(SaltpackFormatName) {
+	if spfn[0] != strings.ToUpper(FormatName) {
 		err = makeErrBadFrame("bad format name (%s)", spfn[0])
 		return
 	}

--- a/key.go
+++ b/key.go
@@ -72,7 +72,7 @@ type BoxSecretKey interface {
 	// specified.
 	Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) []byte
 
-	// Unobx opens up the box, using this secret key as the receiver key
+	// Unbox opens up the box, using this secret key as the receiver key
 	// abd the give public key as the sender key.
 	Unbox(sender BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error)
 

--- a/packets.go
+++ b/packets.go
@@ -18,6 +18,8 @@ type Version struct {
 	Minor   int  `codec:"minor"`
 }
 
+// TODO: Check FormatName in the various Header.validate() functions.
+
 // EncryptionHeader is the first packet in an encrypted message. It contains
 // the encryptions of the session key, and various message metadata. This same
 // struct is used for the signcryption mode as well, though the key types

--- a/packets.go
+++ b/packets.go
@@ -48,7 +48,7 @@ func (h *EncryptionHeader) validate() error {
 	if h.Type != MessageTypeEncryption {
 		return ErrWrongMessageType{MessageTypeEncryption, h.Type}
 	}
-	if h.Version.Major != SaltpackCurrentVersion.Major {
+	if h.Version.Major != CurrentVersion.Major {
 		return ErrBadVersion{h.Version}
 	}
 	return nil
@@ -69,7 +69,7 @@ func (h *SigncryptionHeader) validate() error {
 	if h.Type != MessageTypeSigncryption {
 		return ErrWrongMessageType{MessageTypeSigncryption, h.Type}
 	}
-	if h.Version.Major != SaltpackVersion2.Major {
+	if h.Version.Major != Version2.Major {
 		return ErrBadVersion{h.Version}
 	}
 	return nil
@@ -96,7 +96,7 @@ func newSignatureHeader(sender SigningPublicKey, msgType MessageType) (*Signatur
 
 	header := &SignatureHeader{
 		FormatName:   FormatName,
-		Version:      SaltpackCurrentVersion,
+		Version:      CurrentVersion,
 		Type:         msgType,
 		SenderPublic: sender.ToKID(),
 		Nonce:        nonce[:],
@@ -112,7 +112,7 @@ func (h *SignatureHeader) validate(msgType MessageType) error {
 			received: h.Type,
 		}
 	}
-	if h.Version.Major != SaltpackCurrentVersion.Major {
+	if h.Version.Major != CurrentVersion.Major {
 		return ErrBadVersion{h.Version}
 	}
 

--- a/packets.go
+++ b/packets.go
@@ -50,7 +50,7 @@ func (h *EncryptionHeader) validate() error {
 	if h.Type != MessageTypeEncryption {
 		return ErrWrongMessageType{MessageTypeEncryption, h.Type}
 	}
-	if h.Version.Major != CurrentVersion.Major {
+	if h.Version.Major != CurrentVersion().Major {
 		return ErrBadVersion{h.Version}
 	}
 	return nil
@@ -71,7 +71,7 @@ func (h *SigncryptionHeader) validate() error {
 	if h.Type != MessageTypeSigncryption {
 		return ErrWrongMessageType{MessageTypeSigncryption, h.Type}
 	}
-	if h.Version.Major != Version2.Major {
+	if h.Version.Major != Version2().Major {
 		return ErrBadVersion{h.Version}
 	}
 	return nil
@@ -98,7 +98,7 @@ func newSignatureHeader(sender SigningPublicKey, msgType MessageType) (*Signatur
 
 	header := &SignatureHeader{
 		FormatName:   FormatName,
-		Version:      CurrentVersion,
+		Version:      CurrentVersion(),
 		Type:         msgType,
 		SenderPublic: sender.ToKID(),
 		Nonce:        nonce[:],
@@ -114,7 +114,7 @@ func (h *SignatureHeader) validate(msgType MessageType) error {
 			received: h.Type,
 		}
 	}
-	if h.Version.Major != CurrentVersion.Major {
+	if h.Version.Major != CurrentVersion().Major {
 		return ErrBadVersion{h.Version}
 	}
 

--- a/packets.go
+++ b/packets.go
@@ -95,7 +95,7 @@ func newSignatureHeader(sender SigningPublicKey, msgType MessageType) (*Signatur
 	}
 
 	header := &SignatureHeader{
-		FormatName:   SaltpackFormatName,
+		FormatName:   FormatName,
 		Version:      SaltpackCurrentVersion,
 		Type:         msgType,
 		SenderPublic: sender.ToKID(),

--- a/sign_test.go
+++ b/sign_test.go
@@ -434,7 +434,7 @@ func TestSignCorruptHeader(t *testing.T) {
 
 	// change the version
 	opts.corruptHeader = func(sh *SignatureHeader) {
-		sh.Version = Version{Major: SaltpackCurrentVersion.Major + 1, Minor: 0}
+		sh.Version = Version{Major: CurrentVersion.Major + 1, Minor: 0}
 	}
 	smsg, err = testTweakSign(msg, key, opts)
 	if err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -434,7 +434,7 @@ func TestSignCorruptHeader(t *testing.T) {
 
 	// change the version
 	opts.corruptHeader = func(sh *SignatureHeader) {
-		sh.Version = Version{Major: CurrentVersion.Major + 1, Minor: 0}
+		sh.Version = Version{Major: CurrentVersion().Major + 1, Minor: 0}
 	}
 	smsg, err = testTweakSign(msg, key, opts)
 	if err != nil {

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -195,7 +195,7 @@ func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSym
 
 	eh := &SigncryptionHeader{
 		FormatName: FormatName,
-		Version:    SaltpackVersion2,
+		Version:    Version2,
 		Type:       MessageTypeSigncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 	}

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -194,7 +194,7 @@ func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSym
 	}
 
 	eh := &SigncryptionHeader{
-		FormatName: SaltpackFormatName,
+		FormatName: FormatName,
 		Version:    SaltpackVersion2,
 		Type:       MessageTypeSigncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -195,7 +195,7 @@ func (sss *signcryptSealStream) init(receiverBoxKeys []BoxPublicKey, receiverSym
 
 	eh := &SigncryptionHeader{
 		FormatName: FormatName,
-		Version:    Version2,
+		Version:    Version2(),
 		Type:       MessageTypeSigncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 	}

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -137,7 +137,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 
 	eh := &EncryptionHeader{
 		FormatName: FormatName,
-		Version:    SaltpackCurrentVersion,
+		Version:    CurrentVersion,
 		Type:       MessageTypeEncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 		Receivers:  make([]receiverKeys, 0, len(receivers)),

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -136,7 +136,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 	}
 
 	eh := &EncryptionHeader{
-		FormatName: SaltpackFormatName,
+		FormatName: FormatName,
 		Version:    SaltpackCurrentVersion,
 		Type:       MessageTypeEncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -137,7 +137,7 @@ func (pes *testEncryptStream) init(sender BoxSecretKey, receivers []BoxPublicKey
 
 	eh := &EncryptionHeader{
 		FormatName: FormatName,
-		Version:    CurrentVersion,
+		Version:    CurrentVersion(),
 		Type:       MessageTypeEncryption,
 		Ephemeral:  ephemeralKey.GetPublicKey().ToKID(),
 		Receivers:  make([]receiverKeys, 0, len(receivers)),


### PR DESCRIPTION
This is the recommended Go style.

Also convert some exported vars to functions to avoid
modifications.

Fix a few typos and remove a few extraneous newlines.

Add a TODO for checking FormatName.