### PR TITLE
Fix regex in spec

### DIFF
--- a/specs/saltpack_armor.md
+++ b/specs/saltpack_armor.md
@@ -261,7 +261,7 @@ them appear here.
 1. Collect input up to the first period. This is the header.
 2. Assert that the header matches the regex
    ```
-   [>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE|SIGNED[>\n\r\t ]+MESSAGE|DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*
+   ^[>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE|SIGNED[>\n\r\t ]+MESSAGE|DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*$
    ```
    We match against `>` for compatibility with mail clients that use it for quoting.
    The optional word is an application name (like 'KEYBASE'). The last two words give the

--- a/specs/saltpack_armor.md
+++ b/specs/saltpack_armor.md
@@ -261,7 +261,7 @@ them appear here.
 1. Collect input up to the first period. This is the header.
 2. Assert that the header matches the regex
    ```
-   [>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE)|(SIGNED[>\n\r\t ]+MESSAGE)|(DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*
+   [>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]+)?[>\n\r\t ]+SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE|SIGNED[>\n\r\t ]+MESSAGE|DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*
    ```
    We match against `>` for compatibility with mail clients that use it for quoting.
    The optional word is an application name (like 'KEYBASE'). The last two words give the


### PR DESCRIPTION
The parentheses were wrong. The *or* operator `|` needs to be inside the parentheses.

By the way, you can visualize regexes on https://www.debuggex.com