### PR TITLE
Convert uses of *Nonce to Nonce

### DIFF
--- a/basic/key.go
+++ b/basic/key.go
@@ -64,15 +64,15 @@ func (k PublicKey) CreateEphemeralKey() (saltpack.BoxSecretKey, error) {
 var _ saltpack.BoxPublicKey = PublicKey{}
 
 // Box runs the NaCl box for the given sender and receiver key.
-func (k SecretKey) Box(receiver saltpack.BoxPublicKey, nonce *saltpack.Nonce, msg []byte) []byte {
-	ret := box.Seal([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(receiver.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
+func (k SecretKey) Box(receiver saltpack.BoxPublicKey, nonce saltpack.Nonce, msg []byte) []byte {
+	ret := box.Seal([]byte{}, msg, (*[24]byte)(&nonce), (*[32]byte)(receiver.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
 	return ret
 }
 
 // Unbox runs the NaCl unbox operation on the given ciphertext and nonce,
 // using the receiver as the secret key.
-func (k SecretKey) Unbox(sender saltpack.BoxPublicKey, nonce *saltpack.Nonce, msg []byte) ([]byte, error) {
-	ret, ok := box.Open([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
+func (k SecretKey) Unbox(sender saltpack.BoxPublicKey, nonce saltpack.Nonce, msg []byte) ([]byte, error) {
+	ret, ok := box.Open([]byte{}, msg, (*[24]byte)(&nonce), (*[32]byte)(sender.ToRawBoxKeyPointer()), (*[32]byte)(&k.sec))
 	if !ok {
 		return nil, saltpack.ErrDecryptionFailed
 	}
@@ -103,14 +103,14 @@ func NewSecretKey(pub, sec *[32]byte) SecretKey {
 var _ saltpack.BoxSecretKey = SecretKey{}
 
 // Box runs the box computation given a precomputed key.
-func (k PrecomputedSharedKey) Box(nonce *saltpack.Nonce, msg []byte) []byte {
-	ret := box.SealAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&k))
+func (k PrecomputedSharedKey) Box(nonce saltpack.Nonce, msg []byte) []byte {
+	ret := box.SealAfterPrecomputation([]byte{}, msg, (*[24]byte)(&nonce), (*[32]byte)(&k))
 	return ret
 }
 
 // Unbox runs the unbox computation given a precomputed key.
-func (k PrecomputedSharedKey) Unbox(nonce *saltpack.Nonce, msg []byte) ([]byte, error) {
-	ret, ok := box.OpenAfterPrecomputation([]byte{}, msg, (*[24]byte)(nonce), (*[32]byte)(&k))
+func (k PrecomputedSharedKey) Unbox(nonce saltpack.Nonce, msg []byte) ([]byte, error) {
+	ret, ok := box.OpenAfterPrecomputation([]byte{}, msg, (*[24]byte)(&nonce), (*[32]byte)(&k))
 	if !ok {
 		return nil, saltpack.ErrDecryptionFailed
 	}

--- a/common.go
+++ b/common.go
@@ -147,7 +147,7 @@ func computeMACKey(secret BoxSecretKey, public BoxPublicKey, headerHash headerHa
 	return sliceToByte32(macKeyBox[poly1305.TagSize : poly1305.TagSize+cryptoAuthKeyBytes])
 }
 
-func computePayloadHash(headerHash headerHash, nonce *Nonce, payloadCiphertext []byte) payloadHash {
+func computePayloadHash(headerHash headerHash, nonce Nonce, payloadCiphertext []byte) payloadHash {
 	payloadDigest := sha512.New()
 	payloadDigest.Write(headerHash[:])
 	payloadDigest.Write(nonce[:])

--- a/decrypt.go
+++ b/decrypt.go
@@ -237,7 +237,8 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 	ds.mki.ReceiverKey = secretKey
 
 	// Decrypt the sender's public key
-	senderKeySlice, ok := secretbox.Open([]byte{}, hdr.SenderSecretbox, (*[24]byte)(nonceForSenderKeySecretBox()), (*[32]byte)(ds.payloadKey))
+	nonce := nonceForSenderKeySecretBox()
+	senderKeySlice, ok := secretbox.Open([]byte{}, hdr.SenderSecretbox, (*[24]byte)(&nonce), (*[32]byte)(ds.payloadKey))
 	if !ok {
 		return ErrBadSenderKeySecretbox
 	}
@@ -285,7 +286,7 @@ func (ds *decryptStream) processEncryptionBlock(bl *encryptionBlock) ([]byte, er
 		return nil, ErrBadTag(bl.seqno)
 	}
 
-	plaintext, ok := secretbox.Open([]byte{}, ciphertext, (*[24]byte)(nonce), (*[32]byte)(ds.payloadKey))
+	plaintext, ok := secretbox.Open([]byte{}, ciphertext, (*[24]byte)(&nonce), (*[32]byte)(ds.payloadKey))
 	if !ok {
 		return nil, ErrBadCiphertext(bl.seqno)
 	}

--- a/encrypt.go
+++ b/encrypt.go
@@ -65,7 +65,7 @@ func (es *encryptStream) encryptBytes(b []byte) error {
 	}
 
 	nonce := nonceForChunkSecretBox(es.numBlocks)
-	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(nonce), (*[32]byte)(&es.payloadKey))
+	ciphertext := secretbox.Seal([]byte{}, b, (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
 	block := encryptionBlock{
 		PayloadCiphertext: ciphertext,
@@ -160,7 +160,8 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 		return err
 	}
 
-	eh.SenderSecretbox = secretbox.Seal([]byte{}, sender.GetPublicKey().ToKID(), (*[24]byte)(nonceForSenderKeySecretBox()), (*[32]byte)(&es.payloadKey))
+	nonce := nonceForSenderKeySecretBox()
+	eh.SenderSecretbox = secretbox.Seal([]byte{}, sender.GetPublicKey().ToKID(), (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
 	for _, receiver := range receivers {
 		payloadKeyBox := ephemeralKey.Box(receiver, nonceForPayloadKeyBoxV1(), es.payloadKey[:])

--- a/key.go
+++ b/key.go
@@ -61,8 +61,8 @@ type BoxPublicKey interface {
 
 // BoxPrecomputedSharedKey results from a Precomputation below.
 type BoxPrecomputedSharedKey interface {
-	Unbox(nonce *Nonce, msg []byte) ([]byte, error)
-	Box(nonce *Nonce, msg []byte) []byte
+	Unbox(nonce Nonce, msg []byte) ([]byte, error)
+	Box(nonce Nonce, msg []byte) []byte
 }
 
 // BoxSecretKey is the secret key corresponding to a BoxPublicKey
@@ -70,11 +70,11 @@ type BoxSecretKey interface {
 
 	// Box boxes up data, sent from this secret key, and to the receiver
 	// specified.
-	Box(receiver BoxPublicKey, nonce *Nonce, msg []byte) []byte
+	Box(receiver BoxPublicKey, nonce Nonce, msg []byte) []byte
 
 	// Unbox opens up the box, using this secret key as the receiver key
 	// abd the give public key as the sender key.
-	Unbox(sender BoxPublicKey, nonce *Nonce, msg []byte) ([]byte, error)
+	Unbox(sender BoxPublicKey, nonce Nonce, msg []byte) ([]byte, error)
 
 	// GetPublicKey gets the public key associated with this secret key.
 	GetPublicKey() BoxPublicKey

--- a/nonce.go
+++ b/nonce.go
@@ -11,48 +11,43 @@ const nonceBytes = 24
 // counter values, and some of which can be random-ish values.
 type Nonce [nonceBytes]byte
 
-func nonceForSenderKeySecretBox() *Nonce {
-	var n Nonce = stringToByte24("saltpack_sender_key_sbox")
-	return &n
+func nonceForSenderKeySecretBox() Nonce {
+	return stringToByte24("saltpack_sender_key_sbox")
 }
 
-func nonceForPayloadKeyBoxV1() *Nonce {
-	var n Nonce = stringToByte24("saltpack_payload_key_box")
-	return &n
+func nonceForPayloadKeyBoxV1() Nonce {
+	return stringToByte24("saltpack_payload_key_box")
 }
 
-func nonceForPayloadKeyBoxV2(recip uint64) *Nonce {
-	var n Nonce = stringToByte24("saltpack_recipsbXXXXXXXX")
-	return &n
+func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
+	return stringToByte24("saltpack_recipsbXXXXXXXX")
 }
 
-func nonceForDerivedSharedKey() *Nonce {
-	var n Nonce = stringToByte24("saltpack_derived_sboxkey")
-	return &n
+func nonceForDerivedSharedKey() Nonce {
+	return stringToByte24("saltpack_derived_sboxkey")
 }
 
-func nonceForMACKeyBox(headerHash headerHash) *Nonce {
-	var n Nonce = sliceToByte24(headerHash[:nonceBytes])
-	return &n
+func nonceForMACKeyBox(headerHash headerHash) Nonce {
+	return sliceToByte24(headerHash[:nonceBytes])
 }
 
 // Construct the nonce for the ith block of payload.
-func nonceForChunkSecretBox(i encryptionBlockNumber) *Nonce {
+func nonceForChunkSecretBox(i encryptionBlockNumber) Nonce {
 	var n Nonce
 	copyEqualSizeStr(n[0:16], "saltpack_ploadsb")
 	binary.BigEndian.PutUint64(n[16:], uint64(i))
-	return &n
+	return n
 }
 
 // Construct the nonce for the ith block of payload. Differs in one letter from
 // above. There's almost certainly no harm in using the same nonces here as
 // above, since the encryption keys are ephemeral and the signatures already
 // have their own context, but at the same time it's a good practice.
-func nonceForChunkSigncryption(i encryptionBlockNumber) *Nonce {
+func nonceForChunkSigncryption(i encryptionBlockNumber) Nonce {
 	var n Nonce
 	copyEqualSizeStr(n[0:16], "saltpack_ploadsc")
 	binary.BigEndian.PutUint64(n[16:], uint64(i))
-	return &n
+	return n
 }
 
 // sigNonce is a nonce for signatures.


### PR DESCRIPTION
There's no real need for it, and passing values around
is easier to reason about.