### PR TITLE
Mix in index into payload nonce

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -163,7 +163,8 @@ func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, ephemeralKey
 		return nil, nil, -1, ErrBadLookup
 	}
 
-	payloadKeySlice, err := sk.Unbox(ephemeralKey, nonceForPayloadKeyBoxV1(), hdr.Receivers[orig].PayloadKeyBox)
+	nonce := nonceForPayloadKeyBox(hdr.Version, uint64(orig))
+	payloadKeySlice, err := sk.Unbox(ephemeralKey, nonce, hdr.Receivers[orig].PayloadKeyBox)
 	if err != nil {
 		return nil, nil, -1, err
 	}
@@ -191,7 +192,8 @@ func (ds *decryptStream) tryHiddenReceivers(hdr *EncryptionHeader, ephemeralKey 
 
 		for i, r := range hdr.Receivers {
 			if len(r.ReceiverKID) == 0 {
-				payloadKeySlice, err := shared.Unbox(nonceForPayloadKeyBoxV1(), r.PayloadKeyBox)
+				nonce := nonceForPayloadKeyBox(hdr.Version, uint64(i))
+				payloadKeySlice, err := shared.Unbox(nonce, r.PayloadKeyBox)
 				if err != nil {
 					continue
 				}

--- a/encrypt.go
+++ b/encrypt.go
@@ -163,9 +163,10 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	nonce := nonceForSenderKeySecretBox()
 	eh.SenderSecretbox = secretbox.Seal([]byte{}, sender.GetPublicKey().ToKID(), (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
-	for _, receiver := range receivers {
+	for i, receiver := range receivers {
 		sharedKey := ephemeralKey.Precompute(receiver)
-		payloadKeyBox := sharedKey.Box(nonceForPayloadKeyBoxV1(), es.payloadKey[:])
+		nonce := nonceForPayloadKeyBox(version, uint64(i))
+		payloadKeyBox := sharedKey.Box(nonce, es.payloadKey[:])
 
 		keys := receiverKeys{PayloadKeyBox: payloadKeyBox}
 

--- a/nonce.go
+++ b/nonce.go
@@ -15,10 +15,6 @@ func nonceForSenderKeySecretBox() Nonce {
 	return stringToByte24("saltpack_sender_key_sbox")
 }
 
-func nonceForPayloadKeyBoxV1() Nonce {
-	return stringToByte24("saltpack_payload_key_box")
-}
-
 func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
 	// TODO: Actually mix in recip.
 	return stringToByte24("saltpack_recipsbXXXXXXXX")
@@ -27,7 +23,7 @@ func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
 func nonceForPayloadKeyBox(version Version, recip uint64) Nonce {
 	switch version.Major {
 	case 1:
-		return nonceForPayloadKeyBoxV1()
+		return stringToByte24("saltpack_payload_key_box")
 	case 2:
 		return nonceForPayloadKeyBoxV2(recip)
 	default:

--- a/nonce.go
+++ b/nonce.go
@@ -24,6 +24,19 @@ func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
 	return stringToByte24("saltpack_recipsbXXXXXXXX")
 }
 
+func nonceForPayloadKeyBox(version Version, recip uint64) Nonce {
+	switch version.Major {
+	case 1:
+		return nonceForPayloadKeyBoxV1()
+	case 2:
+		return nonceForPayloadKeyBoxV2(recip)
+	default:
+		// Let caller be responsible for filtering out unknown
+		// versions.
+		panic(ErrBadVersion{version})
+	}
+}
+
 func nonceForDerivedSharedKey() Nonce {
 	return stringToByte24("saltpack_derived_sboxkey")
 }

--- a/nonce.go
+++ b/nonce.go
@@ -16,8 +16,11 @@ func nonceForSenderKeySecretBox() Nonce {
 }
 
 func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
-	// TODO: Actually mix in recip.
-	return stringToByte24("saltpack_recipsbXXXXXXXX")
+	var n Nonce
+	off := len(n) - 8
+	copyEqualSizeStr(n[:off], "saltpack_recipsb")
+	binary.BigEndian.PutUint64(n[off:], uint64(recip))
+	return n
 }
 
 func nonceForPayloadKeyBox(version Version, recip uint64) Nonce {

--- a/nonce_test.go
+++ b/nonce_test.go
@@ -7,6 +7,15 @@ import (
 	"testing"
 )
 
+func TestNonceForPayloadKeyBoxV2(t *testing.T) {
+	nonce1 := nonceForPayloadKeyBoxV2(0)
+	nonce2 := nonceForPayloadKeyBoxV2(1)
+
+	if nonce2 == nonce1 {
+		t.Errorf("nonce2 == nonce1 == %v unexpectedly", nonce1)
+	}
+}
+
 func TestNonceForMACKeyBoxV2(t *testing.T) {
 	hash1 := headerHash{0x01}
 	hash2 := headerHash{0x02}

--- a/nonce_test.go
+++ b/nonce_test.go
@@ -7,12 +7,33 @@ import (
 	"testing"
 )
 
-func TestNonceForPayloadKeyBoxV2(t *testing.T) {
-	nonce1 := nonceForPayloadKeyBoxV2(0)
-	nonce2 := nonceForPayloadKeyBoxV2(1)
+func TestNonceForPayloadKeyBoxV1(t *testing.T) {
+	nonce1 := nonceForPayloadKeyBox(Version1(), 0)
+	nonce2 := nonceForPayloadKeyBox(Version1(), 1)
 
-	if nonce2 == nonce1 {
-		t.Errorf("nonce2 == nonce1 == %v unexpectedly", nonce1)
+	// The V1 MAC key doesn't depend on the index; this is fixed
+	// in V2.
+	if nonce2 != nonce1 {
+		t.Errorf("nonce2 == %v != nonce1 == %v unexpectedly", nonce2, nonce1)
+	}
+}
+
+func TestNonceForPayloadKeyBoxV2(t *testing.T) {
+	nonce1a := nonceForPayloadKeyBoxV2(0)
+	nonce1b := nonceForPayloadKeyBox(Version2(), 0)
+	nonce2a := nonceForPayloadKeyBoxV2(1)
+	nonce2b := nonceForPayloadKeyBox(Version2(), 1)
+
+	if nonce1b != nonce1a {
+		t.Errorf("nonce1b == %v != nonce1a == %v unexpectedly", nonce1b, nonce1a)
+	}
+
+	if nonce2b != nonce2a {
+		t.Errorf("nonce2b == %v != nonce2a == %v unexpectedly", nonce2b, nonce2a)
+	}
+
+	if nonce2a == nonce1a {
+		t.Errorf("nonce2a == nonce1a == %v unexpectedly", nonce1a)
 	}
 }
 

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -165,7 +165,7 @@ func (pes *testEncryptStream) init(version Version, sender BoxSecretKey, receive
 			pes.options.corruptPayloadKey(&payloadKeySlice, rid)
 		}
 
-		nonceTmp := nonceForPayloadKeyBoxV1()
+		nonceTmp := nonceForPayloadKeyBox(version, uint64(rid))
 		if pes.options.corruptKeysNonce != nil {
 			nonceTmp = pes.options.corruptKeysNonce(nonceTmp, rid)
 		}


### PR DESCRIPTION
This prevents leaking whether two recipient public
keys are identical, which can then be used to confirm
guesses of other recipients (by presenting their
public keys as ours).