### PR TITLE
Switch on major versions when reading

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -271,11 +271,13 @@ func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
 }
 
 func computeMACKeyReceiver(version Version, index uint64, secret BoxSecretKey, public, ePublic BoxPublicKey, headerHash headerHash) macKey {
-	switch version {
-	case Version1():
+	// Switch on the major version since we're reading, and so may
+	// encounter headers written by unknown minor versions.
+	switch version.Major {
+	case 1:
 		nonce := nonceForMACKeyBoxV1(headerHash)
 		return computeMACKeySingle(secret, public, nonce)
-	case Version2():
+	case 2:
 		nonce := nonceForMACKeyBoxV2(headerHash, false, index)
 		mac := computeMACKeySingle(secret, public, nonce)
 		eNonce := nonceForMACKeyBoxV2(headerHash, true, index)

--- a/encrypt.go
+++ b/encrypt.go
@@ -198,6 +198,31 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 	return nil
 }
 
+func computeMACKeySender(version Version, index uint64, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+	switch version {
+	case Version1():
+		nonce := nonceForMACKeyBoxV1(headerHash)
+		return computeMACKeySingle(secret, public, nonce)
+	case Version2():
+		nonce := nonceForMACKeyBoxV2(headerHash, false, index)
+		mac := computeMACKeySingle(secret, public, nonce)
+		eNonce := nonceForMACKeyBoxV2(headerHash, true, index)
+		eMAC := computeMACKeySingle(eSecret, public, eNonce)
+		return sum512Truncate256(append(mac[:], eMAC[:]...))
+	default:
+		panic(ErrBadVersion{version})
+	}
+}
+
+func computeMACKeysSender(version Version, sender, ephemeralKey BoxSecretKey, receivers []BoxPublicKey, headerHash headerHash) []macKey {
+	var macKeys []macKey
+	for i, receiver := range receivers {
+		macKey := computeMACKeySender(version, uint64(i), sender, ephemeralKey, receiver, headerHash)
+		macKeys = append(macKeys, macKey)
+	}
+	return macKeys
+}
+
 func (es *encryptStream) Close() error {
 	for es.buffer.Len() > 0 {
 		err := es.encryptBlock()

--- a/encrypt.go
+++ b/encrypt.go
@@ -199,6 +199,8 @@ func (es *encryptStream) init(version Version, sender BoxSecretKey, receivers []
 }
 
 func computeMACKeySender(version Version, index uint64, secret, eSecret BoxSecretKey, public BoxPublicKey, headerHash headerHash) macKey {
+	// Switch on the whole version (i.e., not just the major
+	// version) since we're writing.
 	switch version {
 	case Version1():
 		nonce := nonceForMACKeyBoxV1(headerHash)

--- a/nonce.go
+++ b/nonce.go
@@ -24,6 +24,9 @@ func nonceForPayloadKeyBoxV2(recip uint64) Nonce {
 }
 
 func nonceForPayloadKeyBox(version Version, recip uint64) Nonce {
+	// Switch on the major version since this is called during
+	// both writing and reading, and in the latter we may
+	// encounter headers written by unknown minor versions.
 	switch version.Major {
 	case 1:
 		return stringToByte24("saltpack_payload_key_box")


### PR DESCRIPTION
Otherwise, we may panic when reading a header
from an unknown minor version.

Move some non-common functions out to better places.