### PR TITLE
switch to HMAC for context-mixing operations, for consistency with chat

### DIFF
--- a/const.go
+++ b/const.go
@@ -74,9 +74,13 @@ const signatureDetachedString = "saltpack detached signature\x00"
 // a signcryption signature.
 const signatureEncryptedString = "saltpack encrypted signature\x00"
 
-// signcryptionSymmetricKeyContext gets mixed in with the long term symmetric
-// key and ephemeral key inputs
-const signcryptionSymmetricKeyContext = "saltpack signcryption derived symmetric key\x00"
+// signcryptionDerivedSymmetricKeyContext gets mixed in with the long term symmetric
+// key and ephemeral key inputs, as an HMAC key
+const signcryptionSymmetricKeyContext = "saltpack signcryption derived symmetric key"
+
+// signcryptionBoxKeyIdentifierContext gets mixed in with the DH shared secret
+// as an HMAC key, to make an opaque identifier
+const signcryptionBoxKeyIdentifierContext = "saltpack signcryption box key identifier"
 
 // We truncate HMAC512 to the same link that NaCl's crypto_auth function does.
 const cryptoAuthBytes = 32

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -182,8 +182,7 @@ func (sos *signcryptOpenStream) trySharedSymmetricKeys(hdr *SigncryptionHeader, 
 		}
 
 		// We got a key. It should decrypt the corresponding receiver secretbox.
-		derivedKeyDigest := sha512.New()
-		derivedKeyDigest.Write([]byte(signcryptionSymmetricKeyContext))
+		derivedKeyDigest := hmac.New(sha512.New, []byte(signcryptionSymmetricKeyContext))
 		derivedKeyDigest.Write(ephemeralPub.ToKID())
 		derivedKeyDigest.Write(resolved[:])
 		derivedKey, err := rawBoxKeyFromSlice(derivedKeyDigest.Sum(nil)[0:32])


### PR DESCRIPTION
r? @mlsteele 

We have a similar operation in chat to derive context-specific symmetric keys from TLF keys, so that secretboxes across chat and KBFS can't be confused / exploited.

cc @akalin-keybase