### PR TITLE
Fix two bugs in basex decoder

### DIFF
--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -106,14 +106,14 @@ func testBadArmor62(t *testing.T, version Version) {
 	bad2 := ciphertext[0:1] + "z" + ciphertext[2:]
 	_, _, _, err = Dearmor62DecryptOpen(SingleVersionValidator(version), bad2, kr)
 	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted of type ErrBadFrame; got %v", err)
+		t.Fatalf("Wanted error of type ErrBadFrame; got %v", err)
 	}
 
 	l := len(ciphertext)
 	bad3 := ciphertext[0:(l-8)] + "z" + ciphertext[(l-7):]
 	_, _, _, err = Dearmor62DecryptOpen(SingleVersionValidator(version), bad3, kr)
 	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted of type ErrBadFrmae; got %v", err)
+		t.Fatalf("Wanted error of type ErrBadFrame; got %v", err)
 	}
 
 	bad4 := ciphertext + "䁕"

--- a/armor_test.go
+++ b/armor_test.go
@@ -174,10 +174,7 @@ func TestBinaryInput(t *testing.T) {
 		t.Fatal("timed out waiting for Armor62Open to finish")
 	}
 
-	// PC this seems like a bug to me, but leaving it alone for now:
-	/*
-		if err == nil {
-			t.Errorf("Armor62Open worked on binary data: m == %x, hdr == %q, ftr == %q", m, hdr, ftr)
-		}
-	*/
+	if err == nil {
+		t.Errorf("Armor62Open worked on binary data: m == %v, hdr == %q, ftr == %q", m, hdr, ftr)
+	}
 }

--- a/armor_test.go
+++ b/armor_test.go
@@ -174,7 +174,9 @@ func TestBinaryInput(t *testing.T) {
 		t.Fatal("timed out waiting for Armor62Open to finish")
 	}
 
-	if err == nil {
-		t.Errorf("Armor62Open worked on binary data: m == %v, hdr == %q, ftr == %q", m, hdr, ftr)
+	// Armor62Open shouldtry to find the punctuation for the
+	// header and hit EOF.
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("Armor62Open didn't return io.ErrUnexpectedEOF: m == %v, hdr == %q, ftr == %q, err == %v", m, hdr, ftr, err)
 	}
 }

--- a/armor_test.go
+++ b/armor_test.go
@@ -176,7 +176,7 @@ func TestBinaryInput(t *testing.T) {
 		t.Fatal("timed out waiting for Armor62Open to finish")
 	}
 
-	// Armor62Open shouldtry to find the punctuation for the
+	// Armor62Open should try to find the punctuation for the
 	// header and hit EOF.
 	require.Equal(t, io.ErrUnexpectedEOF, err, "Armor62Open didn't return io.ErrUnexpectedEOF: m == %v, hdr == %q, ftr == %q, err == %v", m, hdr, ftr, err)
 }

--- a/armor_test.go
+++ b/armor_test.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func msg(sz int) []byte {
@@ -176,7 +178,5 @@ func TestBinaryInput(t *testing.T) {
 
 	// Armor62Open shouldtry to find the punctuation for the
 	// header and hit EOF.
-	if err != io.ErrUnexpectedEOF {
-		t.Errorf("Armor62Open didn't return io.ErrUnexpectedEOF: m == %v, hdr == %q, ftr == %q, err == %v", m, hdr, ftr, err)
-	}
+	require.Equal(t, io.ErrUnexpectedEOF, err, "Armor62Open didn't return io.ErrUnexpectedEOF: m == %v, hdr == %q, ftr == %q, err == %v", m, hdr, ftr, err)
 }

--- a/encoding/basex/stream.go
+++ b/encoding/basex/stream.go
@@ -7,7 +7,7 @@ import "io"
 
 // Much of this code is adopted from Go's encoding/base64
 
-// EncodeToString returns the base64 encoding of src.
+// EncodeToString returns the baseX encoding of src.
 func (enc *Encoding) EncodeToString(src []byte) string {
 	buf := make([]byte, enc.EncodedLen(len(src)))
 	enc.Encode(buf, src)
@@ -208,6 +208,7 @@ func (r *filteringReader) Read(p []byte) (int, error) {
 		for i, b := range p[:n] {
 			typ := r.enc.getByteType(b)
 			if typ == invalidByteType {
+				// TODO: Return n?
 				return 0, CorruptInputError(r.nRead)
 			}
 			r.nRead++

--- a/encoding/basex/stream.go
+++ b/encoding/basex/stream.go
@@ -116,21 +116,6 @@ type decoder struct {
 	scratchbuf []byte // a temporary scratch buf, for reuse
 }
 
-func readAtLeast(r io.Reader, buf []byte, min int) (n int, err error) {
-	if len(buf) < min {
-		return 0, io.ErrShortBuffer
-	}
-	for n < min && err == nil {
-		var nn int
-		nn, err = r.Read(buf[n:])
-		n += nn
-	}
-	if n > 0 && err == io.EOF {
-		err = io.ErrUnexpectedEOF
-	}
-	return
-}
-
 func (d *decoder) Read(p []byte) (int, error) {
 
 	if d.err != nil {

--- a/encoding/basex/stream.go
+++ b/encoding/basex/stream.go
@@ -205,7 +205,7 @@ func (r *filteringReader) Read(p []byte) (int, error) {
 		for i, b := range p[:n] {
 			typ := r.enc.getByteType(b)
 			if typ == invalidByteType {
-				// TODO: Return n?
+				// TODO: Return n, i.e. partial results?
 				return 0, CorruptInputError(r.nRead)
 			}
 			r.nRead++

--- a/encoding/basex/stream.go
+++ b/encoding/basex/stream.go
@@ -155,19 +155,16 @@ func (d *decoder) Read(p []byte) (int, error) {
 		nn = len(d.buf)
 	}
 
-	// Try to read up to the next full block. We already have d.nbuf in
-	// there. Need another (obl - d.nbuf) to round up.
-	nn, d.err = readAtLeast(d.r, d.buf[d.nbuf:nn], obl-d.nbuf)
-	d.nbuf += nn
+	// Try to read up to the next full block.
+	for d.nbuf < obl && d.err == nil {
+		var n int
+		n, d.err = d.r.Read(d.buf[d.nbuf:nn])
+		d.nbuf += n
+	}
 
 	eof := false
 
-	// This condition is actually OK, we just shouldn't read any more data
-	// afterwards. We should get an EOF the next time through.
-	if d.err == io.ErrUnexpectedEOF {
-		d.err = nil
-		eof = true
-	} else if d.err == io.EOF {
+	if d.err == io.EOF {
 		if d.nbuf == 0 {
 			return 0, d.err
 		}

--- a/encoding/basex/stream_test.go
+++ b/encoding/basex/stream_test.go
@@ -21,10 +21,16 @@ func (r fakeReader) Read(b []byte) (int, error) {
 	return r.n, r.err
 }
 
+// TestDecodeReaderError tests that errors are propagated properly
+// from the source reader. In particular, if decoder.Read uses
+// io.ReadAtLeast, which drops errors if the minimum is met, then this
+// will fail.
 func TestDecodeReaderError(t *testing.T) {
 	fakeErr := errors.New("fake error")
 	encoding := Base58StdEncoding
-	decoder := NewDecoder(Base58StdEncoding, fakeReader{'1', encoding.baseXBlockLen, fakeErr})
+	// The minimum passed to io.ReadAtLeast is encoding.baseXBlockLen.
+	reader := fakeReader{'1', encoding.baseXBlockLen, fakeErr}
+	decoder := NewDecoder(Base58StdEncoding, reader)
 	var buf [100]byte
 	_, err := decoder.Read(buf[:])
 	if err != fakeErr {

--- a/encoding/basex/stream_test.go
+++ b/encoding/basex/stream_test.go
@@ -1,0 +1,32 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package basex
+
+import (
+	"errors"
+	"testing"
+)
+
+type fakeReader struct {
+	b   byte
+	n   int
+	err error
+}
+
+func (r fakeReader) Read(b []byte) (int, error) {
+	for i := 0; i < r.n; i++ {
+		b[i] = r.b
+	}
+	return r.n, r.err
+}
+
+func TestDecodeReaderError(t *testing.T) {
+	fakeErr := errors.New("fake error")
+	decoder := NewDecoder(Base58StdEncoding, fakeReader{'1', 100, fakeErr})
+	var buf [100]byte
+	_, err := decoder.Read(buf[:])
+	if err != fakeErr {
+		t.Fatalf("Expected %v, got %v", fakeErr, err)
+	}
+}

--- a/encoding/basex/stream_test.go
+++ b/encoding/basex/stream_test.go
@@ -6,6 +6,8 @@ package basex
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type fakeReader struct {
@@ -33,7 +35,5 @@ func TestDecodeReaderError(t *testing.T) {
 	decoder := NewDecoder(Base58StdEncoding, reader)
 	var buf [100]byte
 	_, err := decoder.Read(buf[:])
-	if err != fakeErr {
-		t.Fatalf("Expected %v, got %v", fakeErr, err)
-	}
+	require.Equal(t, fakeErr, err)
 }

--- a/encoding/basex/stream_test.go
+++ b/encoding/basex/stream_test.go
@@ -23,7 +23,8 @@ func (r fakeReader) Read(b []byte) (int, error) {
 
 func TestDecodeReaderError(t *testing.T) {
 	fakeErr := errors.New("fake error")
-	decoder := NewDecoder(Base58StdEncoding, fakeReader{'1', 100, fakeErr})
+	encoding := Base58StdEncoding
+	decoder := NewDecoder(Base58StdEncoding, fakeReader{'1', encoding.baseXBlockLen, fakeErr})
 	var buf [100]byte
 	_, err := decoder.Read(buf[:])
 	if err != fakeErr {


### PR DESCRIPTION
First bug: io.ReadAtLeast drops errors if it reads enough characters.

Second bug: both io.ReadAtLeast and punctuatedReader (among other)
things return io.ErrUnexpectedEOF, so we were dropping errors from
the latter.

The solution to both is to not use io.ReadAtLeast, and instead refill
the buffer manually.

Reenable a test (which was hitting the second bug!).

Fix a few typos.