### PR TITLE
Refactor read loops

### DIFF
--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -45,5 +45,8 @@ func (r *chunkReader) Read(p []byte) (n int, err error) {
 		}
 
 		r.prevChunk, r.prevErr = r.chunker.getNextChunk()
+		if len(r.prevChunk) == 0 && r.prevErr == nil {
+			panic("empty chunk and nil error")
+		}
 	}
 }

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -3,7 +3,7 @@
 
 package saltpack
 
-type chunkStreamer interface {
+type chunker interface {
 	// If getNextChunk returns a non-nil error, the returned chunk
 	// must be empty.
 	//
@@ -14,10 +14,14 @@ type chunkStreamer interface {
 }
 
 type chunkReader struct {
-	streamer chunkStreamer
+	chunker chunker
 	// Invariant: If prevErr is non-nil, prevChunk is empty.
 	prevChunk []byte
 	prevErr   error
+}
+
+func newChunkReader(chunker chunker) *chunkReader {
+	return &chunkReader{chunker: chunker}
 }
 
 func (r *chunkReader) Read(p []byte) (n int, err error) {
@@ -32,7 +36,7 @@ func (r *chunkReader) Read(p []byte) (n int, err error) {
 		}
 
 		// TODO: Check conditions on getNextChunk().
-		r.prevChunk, r.prevErr = r.streamer.getNextChunk()
+		r.prevChunk, r.prevErr = r.chunker.getNextChunk()
 	}
 
 	return n, r.prevErr

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -5,6 +5,9 @@ package saltpack
 
 // chunker is an interface for a type that emits a sequence of
 // plaintext chunks.
+//
+// Implementations should follow exampleChunker in
+// chunk_reader_test.go pretty closely.
 type chunker interface {
 	// getNextChunk() returns a plaintext chunk with an error. If
 	// the chunk is empty, the error must be non-nil. Once

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -28,16 +28,14 @@ func (r *chunkReader) Read(p []byte) (n int, err error) {
 			n += copied
 			r.prevChunk = r.prevChunk[copied:]
 			if len(r.prevChunk) > 0 {
-				break
+				return n, nil
 			}
 		}
 
 		if r.prevErr != nil {
-			break
+			return n, r.prevErr
 		}
 
 		r.prevChunk, r.prevErr = r.chunker.getNextChunk()
 	}
-
-	return n, r.prevErr
 }

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -31,6 +31,7 @@ func (r *chunkReader) Read(p []byte) (n int, err error) {
 	// Copy data into p until it is full, or getNextChunk()
 	// returns a non-nil error.
 	for {
+		// Drain r.prevChunk first before checking for an error.
 		if len(r.prevChunk) > 0 {
 			copied := copy(p[n:], r.prevChunk)
 			n += copied

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -3,6 +3,8 @@
 
 package saltpack
 
+import "fmt"
+
 type chunker interface {
 	// If getNextChunk returns a non-nil error, the returned chunk
 	// must be empty.
@@ -35,8 +37,10 @@ func (r *chunkReader) Read(p []byte) (n int, err error) {
 			}
 		}
 
-		// TODO: Check conditions on getNextChunk().
 		r.prevChunk, r.prevErr = r.chunker.getNextChunk()
+		if len(r.prevChunk) > 0 && r.prevErr != nil {
+			panic(fmt.Sprintf("getNextChunk() returned buffer of size %d with err=%v", len(r.prevChunk), r.prevErr))
+		}
 	}
 
 	return n, r.prevErr

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -11,8 +11,8 @@ package saltpack
 type chunker interface {
 	// getNextChunk() returns a plaintext chunk with an error. If
 	// the chunk is empty, the error must be non-nil. Once
-	// getNextChunk() returns a non-nil error, it can assume that
-	// it will never be called again.
+	// getNextChunk() returns a non-nil error (which may be
+	// io.EOF), it can assume that it will never be called again.
 	getNextChunk() ([]byte, error)
 }
 

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -11,8 +11,7 @@ type chunker interface {
 }
 
 type chunkReader struct {
-	chunker chunker
-	// Invariant: If prevErr is non-nil, prevChunk is empty.
+	chunker   chunker
 	prevChunk []byte
 	prevErr   error
 }

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -33,7 +33,7 @@ func (r *chunkReader) Read(p []byte) (n int, err error) {
 			n += copied
 			r.prevChunk = r.prevChunk[copied:]
 			if len(r.prevChunk) > 0 {
-				return n, nil
+				break
 			}
 		}
 

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -13,32 +13,6 @@ type chunker interface {
 	getNextChunk() ([]byte, error)
 }
 
-// getNextChunk should look like:
-//
-// func (c myChunker) getNextChunk() ([]byte, error) {
-//	var block myBlock
-//	seqno, err := c.mps.Read(&block) // c.mps is a *msgpackStream.
-//	if err != nil {
-//		// An EOF here is unexpected.
-//		if err == io.EOF {
-//			err = io.ErrUnexpectedEOF
-//		}
-//		return nil, err
-//	}
-//
-//	// If processBlock returns a non-nil error, plaintext should be empty.
-//	plaintext, err := c.processBlock(block..., seqno)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	// There should be nothing else after a final block.
-//	if block.IsFinal {
-//		err = assertEndOfStream(c.mps)
-//	}
-//	return plaintext, err
-// }
-
 // chunkReader is an io.Reader adaptor for chunker.
 type chunkReader struct {
 	chunker   chunker

--- a/chunk_reader.go
+++ b/chunk_reader.go
@@ -13,6 +13,32 @@ type chunker interface {
 	getNextChunk() ([]byte, error)
 }
 
+// getNextChunk should look like:
+//
+// func (c myChunker) getNextChunk() ([]byte, error) {
+//	var block myBlock
+//	seqno, err := c.mps.Read(&block) // c.mps is a *msgpackStream.
+//	if err != nil {
+//		// An EOF here is unexpected.
+//		if err == io.EOF {
+//			err = io.ErrUnexpectedEOF
+//		}
+//		return nil, err
+//	}
+//
+//	// If processBlock returns a non-nil error, plaintext should be empty.
+//	plaintext, err := c.processBlock(block..., seqno)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	// There should be nothing else after a final block.
+//	if block.IsFinal {
+//		err = assertEndOfStream(c.mps)
+//	}
+//	return plaintext, err
+// }
+
 // chunkReader is an io.Reader adaptor for chunker.
 type chunkReader struct {
 	chunker   chunker

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -70,7 +70,7 @@ func (c exampleChunker) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(Version2(), chunk, block.Seqno, block.IsFinal)
+	err = checkDecodedChunkState(Version2(), chunk, block.Seqno, block.IsFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -61,6 +61,8 @@ func (c exampleChunker) getNextChunk() ([]byte, error) {
 	}
 
 	// An empty block must only happen with an empty message.
+	// Although for V1, this can be relaxed to checking that an
+	// empty block must be the final block.
 	if len(block.PayloadCiphertext) == 0 && (block.Seqno != 0 || !block.IsFinal) {
 		return nil, ErrUnexpectedEmptyBlock
 	}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +45,9 @@ func testReadAll(t *testing.T, r io.Reader, readSize int) ([]byte, error) {
 	buf := make([]byte, readSize)
 	for {
 		n, err := r.Read(buf)
+		if err == nil {
+			assert.Equal(t, readSize, n)
+		}
 		out = append(out, buf[:n]...)
 		if err != nil {
 			return out, err

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -18,13 +18,13 @@ type testChunker struct {
 	finalErr error
 }
 
-func (s *testChunker) getNextChunk() ([]byte, error) {
-	if len(s.chunks) == 0 {
-		return nil, s.finalErr
+func (c *testChunker) getNextChunk() ([]byte, error) {
+	if len(c.chunks) == 0 {
+		return nil, c.finalErr
 	}
 
-	chunk := s.chunks[0]
-	s.chunks = s.chunks[1:]
+	chunk := c.chunks[0]
+	c.chunks = c.chunks[1:]
 	return chunk, nil
 }
 
@@ -109,4 +109,17 @@ func TestChunkReaderEmptyRead(t *testing.T) {
 	n, err = r.Read(nil)
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, 0, n)
+}
+
+type badChunker struct{}
+
+func (c badChunker) getNextChunk() ([]byte, error) {
+	return []byte{0x1}, io.EOF
+}
+
+func TestBadChunker(t *testing.T) {
+	r := newChunkReader(badChunker{})
+	require.Panics(t, func() {
+		r.Read(nil)
+	})
 }

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -142,3 +142,17 @@ func TestChunkReaderEmptyRead(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, 0, n)
 }
+
+type badChunker struct{}
+
+func (c badChunker) getNextChunk() ([]byte, error) {
+	return nil, nil
+}
+
+func TestChunkReaderBadChunker(t *testing.T) {
+	r := newChunkReader(badChunker{})
+
+	require.Panics(t, func() {
+		r.Read(nil)
+	})
+}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 type exampleBlock struct {
+	// The "encrypted" ciphertext is just the bitwise negation of
+	// the plaintext.
 	PayloadCiphertext []byte
 	Seqno             packetSeqno
 	IsFinal           bool
@@ -34,7 +36,6 @@ func (c exampleChunker) processBlock(block exampleBlock, seqno packetSeqno) ([]b
 		return nil, fmt.Errorf("expected seqno %d, got %d", seqno, block.Seqno)
 	}
 
-	// The "encryption" here is just bitwise negation.
 	chunk := make([]byte, len(block.PayloadCiphertext))
 	for i, b := range block.PayloadCiphertext {
 		chunk[i] = ^b
@@ -72,7 +73,6 @@ func exampleEncode(plaintext []byte) []byte {
 	encoder := newEncoder(buf)
 	for i := 0; i < len(plaintext); i++ {
 		block := exampleBlock{
-			// The "encryption" here is just bitwise negation.
 			PayloadCiphertext: []byte{^plaintext[i]},
 			Seqno:             packetSeqno(i),
 			IsFinal:           i == len(plaintext)-1,

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -92,3 +92,21 @@ func TestChunkReader(t *testing.T) {
 		}
 	}
 }
+
+func TestChunkReaderEmptyRead(t *testing.T) {
+	s := "hello world"
+	chunker := chunkString(s, 5, io.EOF)
+	r := newChunkReader(chunker)
+
+	n, err := r.Read(nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+
+	out, err := testReadAll(t, r, 1)
+	require.Equal(t, io.EOF, err)
+	require.Equal(t, s, string(out))
+
+	n, err = r.Read(nil)
+	require.Equal(t, io.EOF, err)
+	require.Equal(t, 0, n)
+}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -5,6 +5,7 @@ package saltpack
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -64,5 +65,16 @@ func testChunkReader(t *testing.T, s string, chunkSize, readSize int, finalErr e
 }
 
 func TestChunkReader(t *testing.T) {
-	testChunkReader(t, "hello world", 2, 1, errors.New("test error"))
+	inputs := []string{
+		"hello world",
+		"",
+		"somewhat long string",
+	}
+	for _, input := range inputs {
+		// Capture range variable.
+		input := input
+		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
+			testChunkReader(t, input, 2, 1, errors.New("test error"))
+		})
+	}
 }

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -62,7 +62,7 @@ func (c exampleChunker) getNextChunk() ([]byte, error) {
 
 	// An empty block must only happen with an empty message.
 	if len(block.PayloadCiphertext) == 0 && (block.Seqno != 0 || !block.IsFinal) {
-		return nil, errors.New("unexpected empty block")
+		return nil, ErrUnexpectedEmptyBlock
 	}
 
 	// There should be nothing else after a final block.

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -70,11 +70,25 @@ func TestChunkReader(t *testing.T) {
 		"",
 		"somewhat long string",
 	}
+	sizes := []int{1, 3, 5, 1024}
+	errs := []error{
+		errors.New("test error"),
+		io.EOF,
+	}
 	for _, input := range inputs {
-		// Capture range variable.
-		input := input
-		t.Run(fmt.Sprintf("input=%q", input), func(t *testing.T) {
-			testChunkReader(t, input, 2, 1, errors.New("test error"))
-		})
+		for _, chunkSize := range sizes {
+			for _, readSize := range sizes {
+				for _, err := range errs {
+					// Capture range variables.
+					input := input
+					chunkSize := chunkSize
+					readSize := readSize
+					finalErr := err
+					t.Run(fmt.Sprintf("input=%q,chunkSize=%d,readSize=%d,finalErr=%v", input, chunkSize, readSize, finalErr), func(t *testing.T) {
+						testChunkReader(t, input, chunkSize, readSize, finalErr)
+					})
+				}
+			}
+		}
 	}
 }

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -139,8 +139,8 @@ func (c *testChunker) getNextChunk() ([]byte, error) {
 	}
 
 	if len(c.chunks) == 0 {
-		// c.errWithLastChunk can still be set here if call
-		// chunkString with the empty string.
+		// c.errWithLastChunk can still be set here if
+		// chunkString is called with the empty string.
 		c.finalErrHit = true
 		return nil, c.finalErr
 	}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -60,11 +60,9 @@ func (c exampleChunker) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	// An empty block must only happen with an empty message.
-	// Although for V1, this can be relaxed to checking that an
-	// empty block must be the final block.
-	if len(block.PayloadCiphertext) == 0 && (block.Seqno != 0 || !block.IsFinal) {
-		return nil, ErrUnexpectedEmptyBlock
+	err = checkChunkState(Version2(), chunk, uint64(block.Seqno), block.IsFinal)
+	if err != nil {
+		return nil, err
 	}
 
 	// There should be nothing else after a final block.

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -21,6 +21,8 @@ type exampleBlock struct {
 	IsFinal           bool
 }
 
+// exampleChunker is an example implementation of chunker that real
+// implementations should follow pretty closely.
 type exampleChunker struct {
 	mps *msgpackStream
 }

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -5,7 +5,7 @@ package saltpack
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,10 +39,22 @@ func chunkString(s string, chunkSize int, finalErr error) *testChunker {
 	return &testChunker{chunks, finalErr}
 }
 
+func testReadAll(t *testing.T, r io.Reader, readSize int) ([]byte, error) {
+	var out []byte
+	buf := make([]byte, readSize)
+	for {
+		n, err := r.Read(buf)
+		out = append(out, buf[:n]...)
+		if err != nil {
+			return out, err
+		}
+	}
+}
+
 func testChunkReader(t *testing.T, s string, chunkSize, readSize int, finalErr error) {
 	chunker := chunkString(s, chunkSize, finalErr)
 	r := newChunkReader(chunker)
-	out, err := ioutil.ReadAll(r)
+	out, err := testReadAll(t, r, readSize)
 	require.Equal(t, finalErr, err)
 	require.Equal(t, s, string(out))
 }

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testChunker struct {
+	chunks   [][]byte
+	finalErr error
+}
+
+func (s *testChunker) getNextChunk() ([]byte, error) {
+	if len(s.chunks) == 0 {
+		return nil, s.finalErr
+	}
+
+	chunk := s.chunks[0]
+	s.chunks = s.chunks[1:]
+	return chunk, nil
+}
+
+func chunkString(s string, chunkSize int, finalErr error) *testChunker {
+	var chunks [][]byte
+	for len(s) > 0 {
+		n := chunkSize
+		if n > len(s) {
+			n = len(s)
+		}
+		chunks = append(chunks, []byte(s[:n]))
+		s = s[n:]
+	}
+	return &testChunker{chunks, finalErr}
+}
+
+func testChunkReader(t *testing.T, s string, chunkSize, readSize int, finalErr error) {
+	chunker := chunkString(s, chunkSize, finalErr)
+	r := newChunkReader(chunker)
+	out, err := ioutil.ReadAll(r)
+	require.Equal(t, finalErr, err)
+	require.Equal(t, s, string(out))
+}
+
+func TestChunkReader(t *testing.T) {
+	testChunkReader(t, "hello world", 2, 1, errors.New("test error"))
+}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -70,7 +70,7 @@ func (c exampleChunker) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(Version2(), chunk, uint64(block.Seqno), block.IsFinal)
+	err = checkChunkState(Version2(), chunk, block.Seqno, block.IsFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/chunk_reader_test.go
+++ b/chunk_reader_test.go
@@ -110,16 +110,3 @@ func TestChunkReaderEmptyRead(t *testing.T) {
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, 0, n)
 }
-
-type badChunker struct{}
-
-func (c badChunker) getNextChunk() ([]byte, error) {
-	return []byte{0x1}, io.EOF
-}
-
-func TestBadChunker(t *testing.T) {
-	r := newChunkReader(badChunker{})
-	require.Panics(t, func() {
-		r.Read(nil)
-	})
-}

--- a/common.go
+++ b/common.go
@@ -304,10 +304,6 @@ func SingleVersionValidator(desiredVersion Version) VersionValidator {
 	}
 }
 
-// checkSignatureState sanity-checks some signature parameters. When
-// called by the signer, a non-nil error should cause a panic, but
-// when called by the verifier, it should be treated as a regular
-// error.
 func checkSignatureState(version Version, chunk []byte, isFinal bool) error {
 	makeErr := func() error {
 		return fmt.Errorf("invalid signature state: version=%s, len(chunk)=%d, isFinal=%t", version, len(chunk), isFinal)
@@ -340,6 +336,9 @@ func checkSignatureState(version Version, chunk []byte, isFinal bool) error {
 	return nil
 }
 
+// checkChunkState sanity-checks some chunk parameters. When called by
+// encoders, a non-nil error should cause a panic, but when called by
+// decoders, it should be treated as a regular error.
 func checkChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal bool) error {
 	switch version.Major {
 	case 1:
@@ -353,11 +352,11 @@ func checkChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal b
 	case 2:
 		// TODO: Ideally, we'd have tests exercising this case.
 		//
-		// TODO: Make encoding and decoding agree on what
-		// seqno means -- encoding has the first block
-		// starting at seqno 0, whereas decoding has the first
-		// block starting at seqno 1 (since the header block
-		// has seqno 0).
+		// TODO: Make encoders and decoders agree on what
+		// seqno means -- encoders have the first block
+		// starting at seqno 0, whereas decoders have the
+		// first block starting at seqno 1 (since the header
+		// block has seqno 0).
 		if len(chunk) == 0 && (seqno != 1 || !isFinal) {
 			return ErrUnexpectedEmptyBlock
 		}

--- a/common.go
+++ b/common.go
@@ -352,6 +352,12 @@ func checkChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal b
 
 	case 2:
 		// TODO: Ideally, we'd have tests exercising this case.
+		//
+		// TODO: Make encoding and decoding agree on what
+		// seqno means -- encoding has the first block
+		// starting at seqno 0, whereas decoding has the first
+		// block starting at seqno 1 (since the header block
+		// has seqno 0).
 		if len(chunk) == 0 && (seqno != 1 || !isFinal) {
 			return ErrUnexpectedEmptyBlock
 		}

--- a/common.go
+++ b/common.go
@@ -339,3 +339,26 @@ func checkSignatureState(version Version, chunk []byte, isFinal bool) error {
 
 	return nil
 }
+
+func checkChunkState(version Version, chunk []byte, blockIndex uint64, isFinal bool) error {
+	switch version.Major {
+	case 1:
+		// For V1, we derive isFinal from the chunk length, so
+		// if there's a mismatch, that's a bug and not a
+		// stream error.
+		if len(chunk) == 0 != isFinal {
+			panic(fmt.Sprintf("len(chunk)=%d and isFinal=%t", len(chunk), isFinal))
+		}
+
+	case 2:
+		// TODO: Ideally, we'd have tests exercising this case.
+		if len(chunk) == 0 && (blockIndex != 0 || !isFinal) {
+			return ErrUnexpectedEmptyBlock
+		}
+
+	default:
+		panic(ErrBadVersion{version})
+	}
+
+	return nil
+}

--- a/common.go
+++ b/common.go
@@ -287,13 +287,12 @@ func checkChunkState(version Version, chunkLen int, blockIndex uint64, isFinal b
 }
 
 // assertEncodedChunkState sanity-checks some encoded chunk parameters.
-func assertEncodedChunkState(version Version, encodedChunk []byte, encodingOverhead int, seqno packetSeqno, isFinal bool) {
+func assertEncodedChunkState(version Version, encodedChunk []byte, encodingOverhead int, blockIndex uint64, isFinal bool) {
 	if len(encodedChunk) < encodingOverhead {
 		panic("encodedChunk is too small")
 	}
 
-	// The first encoded block has seqno 0.
-	err := checkChunkState(version, len(encodedChunk)-encodingOverhead, uint64(seqno), isFinal)
+	err := checkChunkState(version, len(encodedChunk)-encodingOverhead, blockIndex, isFinal)
 	if err != nil {
 		panic(err)
 	}
@@ -303,5 +302,7 @@ func assertEncodedChunkState(version Version, encodedChunk []byte, encodingOverh
 // parameters. A returned error means there's something wrong with the
 // decoded stream.
 func checkDecodedChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal bool) error {
+	// The first decoded block has seqno 1, since the header bytes
+	// are decoded first.
 	return checkChunkState(version, len(chunk), uint64(seqno-1), isFinal)
 }

--- a/common.go
+++ b/common.go
@@ -304,38 +304,6 @@ func SingleVersionValidator(desiredVersion Version) VersionValidator {
 	}
 }
 
-func checkSignatureState(version Version, chunk []byte, isFinal bool) error {
-	makeErr := func() error {
-		return fmt.Errorf("invalid signature state: version=%s, len(chunk)=%d, isFinal=%t", version, len(chunk), isFinal)
-	}
-
-	switch version.Major {
-	case 1:
-		if (len(chunk) == 0) != isFinal {
-			return makeErr()
-		}
-
-	case 2:
-		// With V2, it's valid to have a final packet with
-		// non-empty chunk, so the below is the only remaining
-		// invalid state.
-		//
-		// TODO: Ideally, we'd disallow empty packets even
-		// with isFinal set, but we still want to allow
-		// signing an empty message. Plumb through an isFirst
-		// flag and change "!isFinal" to "!isFirst ||
-		// !isFinal".
-		if (len(chunk) == 0) && !isFinal {
-			return makeErr()
-		}
-
-	default:
-		panic(ErrBadVersion{version})
-	}
-
-	return nil
-}
-
 // checkChunkState sanity-checks some chunk parameters. When called by
 // encoders, a non-nil error should cause a panic, but when called by
 // decoders, it should be treated as a regular error.

--- a/common.go
+++ b/common.go
@@ -295,7 +295,7 @@ func checkChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal b
 	return nil
 }
 
-func checkEncodedChunkState(version Version, encodedChunk []byte, encodingOverhead int, seqno packetSeqno, isFinal bool) {
+func assertEncodedChunkState(version Version, encodedChunk []byte, encodingOverhead int, seqno packetSeqno, isFinal bool) {
 	if len(encodedChunk) < encodingOverhead {
 		panic("encodedChunk is too small")
 	}

--- a/common.go
+++ b/common.go
@@ -340,19 +340,19 @@ func checkSignatureState(version Version, chunk []byte, isFinal bool) error {
 	return nil
 }
 
-func checkChunkState(version Version, chunk []byte, blockIndex uint64, isFinal bool) error {
+func checkChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal bool) error {
 	switch version.Major {
 	case 1:
 		// For V1, we derive isFinal from the chunk length, so
 		// if there's a mismatch, that's a bug and not a
 		// stream error.
-		if len(chunk) == 0 != isFinal {
+		if (len(chunk) == 0) != isFinal {
 			panic(fmt.Sprintf("len(chunk)=%d and isFinal=%t", len(chunk), isFinal))
 		}
 
 	case 2:
 		// TODO: Ideally, we'd have tests exercising this case.
-		if len(chunk) == 0 && (blockIndex != 0 || !isFinal) {
+		if len(chunk) == 0 && (seqno != 1 || !isFinal) {
 			return ErrUnexpectedEmptyBlock
 		}
 

--- a/common.go
+++ b/common.go
@@ -294,3 +294,14 @@ func checkChunkState(version Version, chunk []byte, seqno packetSeqno, isFinal b
 
 	return nil
 }
+
+func checkEncodedChunkState(version Version, encodedChunk []byte, encodingOverhead int, seqno packetSeqno, isFinal bool) {
+	if len(encodedChunk) < encodingOverhead {
+		panic("encodedChunk is too small")
+	}
+
+	err := checkChunkState(version, encodedChunk[encodingOverhead:], seqno+1, isFinal)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/const.go
+++ b/const.go
@@ -87,13 +87,6 @@ const cryptoAuthBytes = 32
 
 const cryptoAuthKeyBytes = 32
 
-type readState int
-
-const (
-	stateBody readState = iota
-	stateEndOfStream
-)
-
 func (m MessageType) String() string {
 	switch m {
 	case MessageTypeEncryption:

--- a/decrypt.go
+++ b/decrypt.go
@@ -54,7 +54,7 @@ func (ds *decryptStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(ds.version, chunk, uint64(seqno-1), isFinal)
+	err = checkChunkState(ds.version, chunk, seqno, isFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/decrypt.go
+++ b/decrypt.go
@@ -59,20 +59,20 @@ func (ds *decryptStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	if len(chunk) == 0 {
-		switch ds.version.Major {
-		case 1:
-			if !isFinal {
-				return nil, ErrUnexpectedEmptyBlock
-			}
-		case 2:
-			// TODO: Ideally, we'd have a test exercising this case.
-			if seqno != 1 || !isFinal {
-				return nil, ErrUnexpectedEmptyBlock
-			}
-		default:
-			panic(ErrBadVersion{ds.version})
+	switch ds.version.Major {
+	case 1:
+		if len(chunk) == 0 && !isFinal {
+			return nil, ErrUnexpectedEmptyBlock
+		} else if len(chunk) != 0 && isFinal {
+			return nil, ErrUnexpectedNonEmptyFinalBlockV1
 		}
+	case 2:
+		// TODO: Ideally, we'd have a test exercising this case.
+		if len(chunk) == 0 && (seqno != 1 || !isFinal) {
+			return nil, ErrUnexpectedEmptyBlock
+		}
+	default:
+		panic(ErrBadVersion{ds.version})
 	}
 
 	if isFinal {

--- a/decrypt.go
+++ b/decrypt.go
@@ -54,7 +54,7 @@ func (ds *decryptStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(ds.version, chunk, seqno, isFinal)
+	err = checkDecodedChunkState(ds.version, chunk, seqno, isFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/decrypt.go
+++ b/decrypt.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha512"
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -19,11 +18,8 @@ type decryptStream struct {
 	version          Version
 	ring             Keyring
 	mps              *msgpackStream
-	err              error
-	state            readState
 	payloadKey       *SymmetricKey
 	senderKey        *RawBoxKey
-	buf              []byte
 	headerHash       headerHash
 	macKey           macKey
 	position         int
@@ -86,65 +82,6 @@ func (ds *decryptStream) getNextChunk() ([]byte, error) {
 	return chunk, nil
 }
 
-func (ds *decryptStream) read(b []byte) (n int, err error) {
-
-	// Handle the case of a previous error. Just return the error
-	// again.
-	if ds.err != nil {
-		return 0, ds.err
-	}
-
-	// Handle the case first of a previous read that couldn't put all
-	// of its data into the outgoing buffer.
-	if len(ds.buf) > 0 {
-		n = copy(b, ds.buf)
-		ds.buf = ds.buf[n:]
-		return n, nil
-	}
-
-	// We have two states we can be in, but we can definitely
-	// fall through during one read, so be careful.
-
-	if ds.state == stateBody {
-		var last bool
-		n, last, ds.err = ds.readBlock(b)
-		if ds.err != nil {
-			return 0, ds.err
-		} else if !last {
-			return n, nil
-		}
-
-		ds.state = stateEndOfStream
-		// If we've reached the end of the stream, but have
-		// data left (which only happens in V2), return so
-		// that the next call(s) will hit the case at the top,
-		// and then we'll hit the case below.
-		if len(ds.buf) > 0 {
-			switch ds.version.Major {
-			case 1:
-				panic(fmt.Sprintf("version=%s, last=true, len(ds.buf)=%d > 0", ds.version, len(ds.buf)))
-			case 2:
-				// Do nothing.
-			default:
-				panic(ErrBadVersion{ds.version})
-			}
-
-			return n, nil
-		}
-	}
-
-	if ds.state == stateEndOfStream {
-		ds.err = assertEndOfStream(ds.mps)
-		// If V2, we can fall through here with n > 0. Even if
-		// we have an error, we still want to return n, since
-		// those bytes are authenticated (by readBlock's
-		// post-condition).
-		return n, ds.err
-	}
-
-	panic(fmt.Sprintf("Should never get here: state=%v", ds.state))
-}
-
 func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 	// Read the header bytes.
 	headerBytes := []byte{}
@@ -165,7 +102,6 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	ds.state = stateBody
 	return nil
 }
 
@@ -190,33 +126,6 @@ func readEncryptionBlock(version Version, mps *msgpackStream) (ciphertext []byte
 	default:
 		panic(ErrBadVersion{version})
 	}
-}
-
-// readBlock reads the next encryption block and copies authenticated
-// data into p. If readBlock returns a non-nil error, then n will be
-// 0.
-func (ds *decryptStream) readBlock(b []byte) (n int, lastBlock bool, err error) {
-	ciphertext, authenticators, isFinal, seqno, err := readEncryptionBlock(ds.version, ds.mps)
-	if err != nil {
-		return 0, false, err
-	}
-
-	err = checkCiphertextState(ds.version, ciphertext, isFinal)
-	if err != nil {
-		return 0, false, err
-	}
-
-	plaintext, err := ds.processEncryptionBlock(ciphertext, authenticators, isFinal, seqno)
-	if err != nil {
-		return 0, false, err
-	}
-
-	// Copy as much as we can into the given outbuffer
-	n = copy(b, plaintext)
-	// Leave the remainder for a subsequent read
-	ds.buf = plaintext[n:]
-
-	return n, isFinal, nil
 }
 
 func (ds *decryptStream) tryVisibleReceivers(hdr *EncryptionHeader, ephemeralKey BoxPublicKey) (BoxSecretKey, *SymmetricKey, int, error) {

--- a/encrypt.go
+++ b/encrypt.go
@@ -119,7 +119,7 @@ func (es *encryptStream) encryptBlock(isFinal bool) error {
 	nonce := nonceForChunkSecretBox(es.numBlocks)
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
-	assertEncodedChunkState(es.version, ciphertext, secretbox.Overhead, packetSeqno(es.numBlocks), isFinal)
+	assertEncodedChunkState(es.version, ciphertext, secretbox.Overhead, uint64(es.numBlocks), isFinal)
 
 	// Compute the digest to authenticate, and authenticate it for each
 	// recipient.

--- a/encrypt.go
+++ b/encrypt.go
@@ -116,12 +116,10 @@ func (es *encryptStream) encryptBlock(isFinal bool) error {
 		return err
 	}
 
-	if err := checkChunkState(es.version, plaintext, packetSeqno(es.numBlocks+1), isFinal); err != nil {
-		panic(err)
-	}
-
 	nonce := nonceForChunkSecretBox(es.numBlocks)
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
+
+	checkEncodedChunkState(es.version, ciphertext, secretbox.Overhead, packetSeqno(es.numBlocks), isFinal)
 
 	// Compute the digest to authenticate, and authenticate it for each
 	// recipient.

--- a/encrypt.go
+++ b/encrypt.go
@@ -116,13 +116,12 @@ func (es *encryptStream) encryptBlock(isFinal bool) error {
 		return err
 	}
 
-	nonce := nonceForChunkSecretBox(es.numBlocks)
-	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
-
-	if err := checkCiphertextState(es.version, ciphertext, isFinal); err != nil {
-		// We should always create valid ciphertext states.
+	if err := checkChunkState(es.version, plaintext, packetSeqno(es.numBlocks+1), isFinal); err != nil {
 		panic(err)
 	}
+
+	nonce := nonceForChunkSecretBox(es.numBlocks)
+	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
 	// Compute the digest to authenticate, and authenticate it for each
 	// recipient.

--- a/encrypt.go
+++ b/encrypt.go
@@ -119,7 +119,7 @@ func (es *encryptStream) encryptBlock(isFinal bool) error {
 	nonce := nonceForChunkSecretBox(es.numBlocks)
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&es.payloadKey))
 
-	checkEncodedChunkState(es.version, ciphertext, secretbox.Overhead, packetSeqno(es.numBlocks), isFinal)
+	assertEncodedChunkState(es.version, ciphertext, secretbox.Overhead, packetSeqno(es.numBlocks), isFinal)
 
 	// Compute the digest to authenticate, and authenticate it for each
 	// recipient.

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -377,7 +377,7 @@ func testRoundTrip(t *testing.T, version Version, msg []byte, receivers []BoxPub
 		t.Fatal(err)
 	}
 	if !bytes.Equal(plaintext, msg) {
-		t.Fatalf("decryption mismatch: %v != %v", plaintext, msg)
+		t.Fatalf("decryption mismatch: %x != %x", plaintext, msg)
 	}
 }
 

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -240,14 +240,13 @@ func slowRead(r io.Reader, sz int) ([]byte, error) {
 	var res []byte
 	for eof := false; !eof; {
 		n, err := r.Read(buf)
-		if n == 0 || err == io.EOF {
-			eof = true
+		res = append(res, buf[:n]...)
+		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, buf[0:n]...)
 	}
 	return res, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -67,6 +67,10 @@ var (
 	// the same length as the identifiers list.
 	ErrWrongNumberOfKeys = errors.New("wrong number of resolved keys")
 
+	// ErrUnexpectedNonEmptyFinalBlockV1 is returned when a
+	// non-empty final block in a V1 stream.
+	ErrUnexpectedNonEmptyFinalBlockV1 = errors.New("unexpected non-empty final block (V1)")
+
 	// ErrUnexpectedEmptyBlock is returned when an empty block is
 	// encountered that isn't both the last one and the first one
 	// (for V2 and higher), or isn't the last one (for V1).

--- a/errors.go
+++ b/errors.go
@@ -67,10 +67,6 @@ var (
 	// the same length as the identifiers list.
 	ErrWrongNumberOfKeys = errors.New("wrong number of resolved keys")
 
-	// ErrUnexpectedNonEmptyFinalBlockV1 is returned when a
-	// non-empty final block in a V1 stream.
-	ErrUnexpectedNonEmptyFinalBlockV1 = errors.New("unexpected non-empty final block (V1)")
-
 	// ErrUnexpectedEmptyBlock is returned when an empty block is
 	// encountered that isn't both the last one and the first one
 	// (for V2 and higher), or isn't the last one (for V1).

--- a/errors.go
+++ b/errors.go
@@ -66,6 +66,11 @@ var (
 	// ErrWrongNumberOfKeys is returned when the resolved list of keys isn't
 	// the same length as the identifiers list.
 	ErrWrongNumberOfKeys = errors.New("wrong number of resolved keys")
+
+	// ErrUnexpectedEmptyBlock is returned when an empty block is
+	// encountered that isn't both the last one and the first one
+	// (for V2 and higher), or isn't the last one (for V1).
+	ErrUnexpectedEmptyBlock = errors.New("unexpected empty block")
 )
 
 // ErrBadTag is generated when a payload hash doesn't match the hash

--- a/sign_stream.go
+++ b/sign_stream.go
@@ -174,6 +174,8 @@ func (s *signAttachedStream) signBlock(isFinal bool) error {
 		return err
 	}
 
+	checkEncodedChunkState(s.version, chunk, 0, s.seqno, isFinal)
+
 	sBlock := makeSignatureBlock(s.version, sig, chunk, isFinal)
 	if err := s.encoder.Encode(sBlock); err != nil {
 		return err

--- a/sign_stream.go
+++ b/sign_stream.go
@@ -165,13 +165,13 @@ func (s *signAttachedStream) signBlock(isFinal bool) error {
 	chunk := s.buffer.Next(signatureBlockSize)
 	checkSignBlockRead(s.version, isFinal, signatureBlockSize, len(chunk), s.buffer.Len())
 
+	if err := checkChunkState(s.version, chunk, s.seqno+1, isFinal); err != nil {
+		panic(err)
+	}
+
 	sig, err := s.computeSig(chunk, s.seqno, isFinal)
 	if err != nil {
 		return err
-	}
-
-	if err := checkChunkState(s.version, chunk, s.seqno+1, isFinal); err != nil {
-		panic(err)
 	}
 
 	sBlock := makeSignatureBlock(s.version, sig, chunk, isFinal)

--- a/sign_stream.go
+++ b/sign_stream.go
@@ -165,10 +165,6 @@ func (s *signAttachedStream) signBlock(isFinal bool) error {
 	chunk := s.buffer.Next(signatureBlockSize)
 	checkSignBlockRead(s.version, isFinal, signatureBlockSize, len(chunk), s.buffer.Len())
 
-	if err := checkChunkState(s.version, chunk, s.seqno+1, isFinal); err != nil {
-		panic(err)
-	}
-
 	sig, err := s.computeSig(chunk, s.seqno, isFinal)
 	if err != nil {
 		return err

--- a/sign_stream.go
+++ b/sign_stream.go
@@ -170,7 +170,7 @@ func (s *signAttachedStream) signBlock(isFinal bool) error {
 		return err
 	}
 
-	if err := checkSignatureState(s.version, chunk, isFinal); err != nil {
+	if err := checkChunkState(s.version, chunk, s.seqno+1, isFinal); err != nil {
 		panic(err)
 	}
 

--- a/sign_stream.go
+++ b/sign_stream.go
@@ -174,7 +174,7 @@ func (s *signAttachedStream) signBlock(isFinal bool) error {
 		return err
 	}
 
-	checkEncodedChunkState(s.version, chunk, 0, s.seqno, isFinal)
+	assertEncodedChunkState(s.version, chunk, 0, s.seqno, isFinal)
 
 	sBlock := makeSignatureBlock(s.version, sig, chunk, isFinal)
 	if err := s.encoder.Encode(sBlock); err != nil {

--- a/sign_stream.go
+++ b/sign_stream.go
@@ -170,7 +170,7 @@ func (s *signAttachedStream) signBlock(isFinal bool) error {
 		return err
 	}
 
-	assertEncodedChunkState(s.version, chunk, 0, s.seqno, isFinal)
+	assertEncodedChunkState(s.version, chunk, 0, uint64(s.seqno), isFinal)
 
 	sBlock := makeSignatureBlock(s.version, sig, chunk, isFinal)
 	if err := s.encoder.Encode(sBlock); err != nil {

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -39,7 +39,7 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(Version2(), chunk, uint64(seqno-1), sb.IsFinal)
+	err = checkChunkState(Version2(), chunk, seqno, sb.IsFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -18,7 +18,6 @@ type signcryptOpenStream struct {
 	mps *msgpackStream
 	err error
 
-	chunkReader      *chunkReader
 	payloadKey       *SymmetricKey
 	signingPublicKey SigningPublicKey
 	senderAnonymous  bool

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -39,7 +39,7 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(Version2(), chunk, seqno, sb.IsFinal)
+	err = checkDecodedChunkState(Version2(), chunk, seqno, sb.IsFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -35,7 +35,7 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	chunk, err := sos.processSigncryptionBlock(sb.PayloadCiphertext, sb.IsFinal, seqno)
+	chunk, err := sos.processBlock(sb.PayloadCiphertext, sb.IsFinal, seqno)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (sos *signcryptOpenStream) processSigncryptionHeader(hdr *SigncryptionHeade
 	return nil
 }
 
-func (sos *signcryptOpenStream) processSigncryptionBlock(payloadCiphertext []byte, isFinal bool, seqno packetSeqno) ([]byte, error) {
+func (sos *signcryptOpenStream) processBlock(payloadCiphertext []byte, isFinal bool, seqno packetSeqno) ([]byte, error) {
 
 	blockNum := encryptionBlockNumber(seqno - 1)
 

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -15,9 +15,7 @@ import (
 )
 
 type signcryptOpenStream struct {
-	mps *msgpackStream
-	err error
-
+	mps              *msgpackStream
 	payloadKey       *SymmetricKey
 	signingPublicKey SigningPublicKey
 	senderAnonymous  bool
@@ -27,10 +25,6 @@ type signcryptOpenStream struct {
 }
 
 func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
-	if sos.err != nil {
-		return nil, sos.err
-	}
-
 	var sb signcryptionBlock
 	seqno, err := sos.mps.Read(&sb)
 	if err != nil {
@@ -46,10 +40,9 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 	}
 
 	if sb.IsFinal {
-		sos.err = assertEndOfStream(sos.mps)
+		err = assertEndOfStream(sos.mps)
 	}
-
-	return plaintext, nil
+	return plaintext, err
 }
 
 func (sos *signcryptOpenStream) readHeader(mps *msgpackStream) error {

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -247,9 +247,7 @@ func NewSigncryptOpenStream(r io.Reader, keyring SigncryptKeyring, resolver Symm
 		return nil, nil, err
 	}
 
-	chunkReader := newChunkReader(sos)
-
-	return sos.signingPublicKey, chunkReader, nil
+	return sos.signingPublicKey, newChunkReader(sos), nil
 }
 
 type SymmetricKeyResolver interface {

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -39,9 +39,9 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	// TODO: Ideally, we'd have a test exercising this case.
-	if len(chunk) == 0 && (seqno != 1 || !sb.IsFinal) {
-		return nil, ErrUnexpectedEmptyBlock
+	err = checkChunkState(Version2(), chunk, uint64(seqno-1), sb.IsFinal)
+	if err != nil {
+		return nil, err
 	}
 
 	if sb.IsFinal {

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -257,12 +257,12 @@ func NewSigncryptOpenStream(r io.Reader, keyring SigncryptKeyring, resolver Symm
 		resolver: resolver,
 	}
 
-	sos.chunkReader = newChunkReader(&signcryptionChunker{sos, nil})
-
 	err = sos.readHeader(r)
 	if err != nil {
-		return sos.signingPublicKey, nil, err
+		return nil, nil, err
 	}
+
+	sos.chunkReader = newChunkReader(&signcryptionChunker{sos, nil})
 
 	return sos.signingPublicKey, sos, nil
 }

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha512"
-	"errors"
 	"io"
 	"io/ioutil"
 
@@ -42,7 +41,7 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 
 	// TODO: Ideally, we'd have a test exercising this case.
 	if len(chunk) == 0 && (seqno != 1 || !sb.IsFinal) {
-		return nil, errors.New("unexpected empty block")
+		return nil, ErrUnexpectedEmptyBlock
 	}
 
 	if sb.IsFinal {

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -49,8 +49,6 @@ type signcryptOpenStream struct {
 	mps         *msgpackStream
 	chunkReader *chunkReader
 
-	err              error
-	state            readState
 	payloadKey       *SymmetricKey
 	signingPublicKey SigningPublicKey
 	senderAnonymous  bool
@@ -84,7 +82,6 @@ func (sos *signcryptOpenStream) readHeader(rawReader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	sos.state = stateBody
 	return nil
 }
 

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -34,7 +34,7 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	plaintext, err := sos.processSigncryptionBlock(sb.PayloadCiphertext, sb.IsFinal, seqno)
+	chunk, err := sos.processSigncryptionBlock(sb.PayloadCiphertext, sb.IsFinal, seqno)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,8 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 	if sb.IsFinal {
 		err = assertEndOfStream(sos.mps)
 	}
-	return plaintext, err
+
+	return chunk, err
 }
 
 func (sos *signcryptOpenStream) readHeader(mps *msgpackStream) error {
@@ -214,10 +215,6 @@ func (sos *signcryptOpenStream) processSigncryptionBlock(payloadCiphertext []byt
 		}
 	}
 
-	// The encoding of the empty buffer implies the EOF.  But otherwise, all mechanisms are the same.
-	if len(chunkPlaintext) == 0 {
-		return nil, nil
-	}
 	return chunkPlaintext, nil
 }
 

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -84,7 +84,7 @@ func (sss *signcryptSealStream) signcryptBlock(isFinal bool) error {
 
 	ciphertext := secretbox.Seal([]byte{}, attachedSig, (*[24]byte)(&nonce), (*[32]byte)(&sss.encryptionKey))
 
-	assertEncodedChunkState(sss.version, ciphertext, secretbox.Overhead, packetSeqno(sss.numBlocks), isFinal)
+	assertEncodedChunkState(sss.version, ciphertext, secretbox.Overhead, uint64(sss.numBlocks), isFinal)
 
 	block := signcryptionBlock{
 		PayloadCiphertext: ciphertext,

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -63,10 +63,6 @@ func (sss *signcryptSealStream) signcryptBlock(isFinal bool) error {
 		return err
 	}
 
-	if err := checkChunkState(sss.version, plaintext, packetSeqno(sss.numBlocks+1), isFinal); err != nil {
-		panic(err)
-	}
-
 	nonce := nonceForChunkSigncryption(sss.headerHash, isFinal, sss.numBlocks)
 
 	// Handle regular signing mode and anonymous mode (where we don't actually
@@ -87,6 +83,8 @@ func (sss *signcryptSealStream) signcryptBlock(isFinal bool) error {
 	attachedSig := append(detachedSig, plaintext...)
 
 	ciphertext := secretbox.Seal([]byte{}, attachedSig, (*[24]byte)(&nonce), (*[32]byte)(&sss.encryptionKey))
+
+	checkEncodedChunkState(sss.version, ciphertext, secretbox.Overhead, packetSeqno(sss.numBlocks), isFinal)
 
 	block := signcryptionBlock{
 		PayloadCiphertext: ciphertext,

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -84,7 +84,7 @@ func (sss *signcryptSealStream) signcryptBlock(isFinal bool) error {
 
 	ciphertext := secretbox.Seal([]byte{}, attachedSig, (*[24]byte)(&nonce), (*[32]byte)(&sss.encryptionKey))
 
-	checkEncodedChunkState(sss.version, ciphertext, secretbox.Overhead, packetSeqno(sss.numBlocks), isFinal)
+	assertEncodedChunkState(sss.version, ciphertext, secretbox.Overhead, packetSeqno(sss.numBlocks), isFinal)
 
 	block := signcryptionBlock{
 		PayloadCiphertext: ciphertext,

--- a/signcrypt_test.go
+++ b/signcrypt_test.go
@@ -137,6 +137,23 @@ func TestSigncryptionEmptyCiphertext(t *testing.T) {
 	require.Equal(t, ErrFailedToReadHeaderBytes, err)
 }
 
+func TestSigncryptionMultiPacket(t *testing.T) {
+	msg := make([]byte, encryptionBlockSize*2)
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealed, err := SigncryptSeal(msg, keyring, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	senderPub, opened, err := SigncryptOpen(sealed, keyring, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, senderSigningPrivKey.GetPublicKey(), senderPub)
+
+	require.Equal(t, msg, opened)
+}
+
 func getHeaderLen(t *testing.T, sealed []byte) int {
 	// Assert the MessagePack bin8 type.
 	require.Equal(t, byte(0xc4), sealed[0])

--- a/signcrypt_test.go
+++ b/signcrypt_test.go
@@ -348,10 +348,12 @@ func TestSigncryptionStream(t *testing.T) {
 	for {
 		buffer := make([]byte, 1)
 		n, err := reader.Read(buffer)
-		if n == 0 || err == io.EOF {
+		output = append(output, buffer[:n]...)
+		if err == io.EOF {
 			break
 		}
-		output = append(output, buffer...)
+		require.NoError(t, err)
+		require.True(t, n > 0)
 	}
 	require.Equal(t, msg, output)
 }

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -90,7 +90,7 @@ func (pes *testEncryptStream) encryptBlock(isFinal bool) error {
 
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&pes.payloadKey))
 
-	assertEncodedChunkState(pes.version, ciphertext, secretbox.Overhead, packetSeqno(pes.numBlocks), isFinal)
+	assertEncodedChunkState(pes.version, ciphertext, secretbox.Overhead, uint64(pes.numBlocks), isFinal)
 
 	if pes.options.corruptCiphertextBeforeHash != nil {
 		pes.options.corruptCiphertextBeforeHash(ciphertext, pes.numBlocks)

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -82,6 +82,10 @@ func (pes *testEncryptStream) encryptBlock(isFinal bool) error {
 		return err
 	}
 
+	if err := checkChunkState(pes.version, plaintext, packetSeqno(pes.numBlocks+1), isFinal); err != nil {
+		panic(err)
+	}
+
 	nonce := nonceForChunkSecretBox(pes.numBlocks)
 
 	if pes.options.corruptPayloadNonce != nil {
@@ -89,11 +93,6 @@ func (pes *testEncryptStream) encryptBlock(isFinal bool) error {
 	}
 
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&pes.payloadKey))
-
-	if err := checkCiphertextState(pes.version, ciphertext, isFinal); err != nil {
-		// We should always create valid ciphertext states.
-		panic(err)
-	}
 
 	if pes.options.corruptCiphertextBeforeHash != nil {
 		pes.options.corruptCiphertextBeforeHash(ciphertext, pes.numBlocks)

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -90,7 +90,7 @@ func (pes *testEncryptStream) encryptBlock(isFinal bool) error {
 
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&pes.payloadKey))
 
-	checkEncodedChunkState(pes.version, ciphertext, secretbox.Overhead, packetSeqno(pes.numBlocks), isFinal)
+	assertEncodedChunkState(pes.version, ciphertext, secretbox.Overhead, packetSeqno(pes.numBlocks), isFinal)
 
 	if pes.options.corruptCiphertextBeforeHash != nil {
 		pes.options.corruptCiphertextBeforeHash(ciphertext, pes.numBlocks)

--- a/tweakable_encryptor_test.go
+++ b/tweakable_encryptor_test.go
@@ -82,10 +82,6 @@ func (pes *testEncryptStream) encryptBlock(isFinal bool) error {
 		return err
 	}
 
-	if err := checkChunkState(pes.version, plaintext, packetSeqno(pes.numBlocks+1), isFinal); err != nil {
-		panic(err)
-	}
-
 	nonce := nonceForChunkSecretBox(pes.numBlocks)
 
 	if pes.options.corruptPayloadNonce != nil {
@@ -93,6 +89,8 @@ func (pes *testEncryptStream) encryptBlock(isFinal bool) error {
 	}
 
 	ciphertext := secretbox.Seal([]byte{}, plaintext, (*[24]byte)(&nonce), (*[32]byte)(&pes.payloadKey))
+
+	checkEncodedChunkState(pes.version, ciphertext, secretbox.Overhead, packetSeqno(pes.numBlocks), isFinal)
 
 	if pes.options.corruptCiphertextBeforeHash != nil {
 		pes.options.corruptCiphertextBeforeHash(ciphertext, pes.numBlocks)

--- a/tweakable_signer_test.go
+++ b/tweakable_signer_test.go
@@ -138,7 +138,7 @@ func (s *testSignStream) signBlock(isFinal bool) error {
 		return err
 	}
 
-	assertEncodedChunkState(s.version, chunk, 0, s.seqno, isFinal)
+	assertEncodedChunkState(s.version, chunk, 0, uint64(s.seqno), isFinal)
 
 	sBlock := makeSignatureBlock(s.version, sig, chunk, isFinal)
 

--- a/tweakable_signer_test.go
+++ b/tweakable_signer_test.go
@@ -138,9 +138,7 @@ func (s *testSignStream) signBlock(isFinal bool) error {
 		return err
 	}
 
-	if err := checkChunkState(s.version, chunk, s.seqno+1, isFinal); err != nil {
-		panic(err)
-	}
+	assertEncodedChunkState(s.version, chunk, 0, s.seqno, isFinal)
 
 	sBlock := makeSignatureBlock(s.version, sig, chunk, isFinal)
 

--- a/tweakable_signer_test.go
+++ b/tweakable_signer_test.go
@@ -138,7 +138,7 @@ func (s *testSignStream) signBlock(isFinal bool) error {
 		return err
 	}
 
-	if err := checkSignatureState(s.version, chunk, isFinal); err != nil {
+	if err := checkChunkState(s.version, chunk, s.seqno+1, isFinal); err != nil {
 		panic(err)
 	}
 

--- a/verify.go
+++ b/verify.go
@@ -56,7 +56,7 @@ func VerifyDetachedReader(versionValidator VersionValidator, message io.Reader, 
 
 	// Reach inside the verifyStream to parse the signature bytes.
 	var naclSignature []byte
-	_, err = s.stream.Read(&naclSignature)
+	_, err = s.mps.Read(&naclSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/verify.go
+++ b/verify.go
@@ -24,7 +24,7 @@ func NewVerifyStream(versionValidator VersionValidator, r io.Reader, keyring Sig
 		return nil, nil, ErrNoSenderKey
 	}
 	s.publicKey = skey
-	return skey, s, nil
+	return skey, newChunkReader(s), nil
 }
 
 // Verify checks the signature in signedMsg. It returns the

--- a/verify_stream.go
+++ b/verify_stream.go
@@ -4,7 +4,6 @@
 package saltpack
 
 import (
-	"errors"
 	"fmt"
 	"io"
 )
@@ -104,7 +103,7 @@ func (v *verifyStream) getNextChunk() ([]byte, error) {
 
 	// TODO: Ideally, we'd have a test exercising this case.
 	if len(chunk) == 0 && (seqno != 0 || !isFinal) {
-		return nil, errors.New("unexpected empty block")
+		return nil, ErrUnexpectedEmptyBlock
 	}
 
 	if isFinal {

--- a/verify_stream.go
+++ b/verify_stream.go
@@ -39,7 +39,7 @@ func (v *verifyStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(v.header.Version, chunk, uint64(seqno-1), isFinal)
+	err = checkChunkState(v.header.Version, chunk, seqno, isFinal)
 	if err != nil {
 		return nil, err
 	}

--- a/verify_stream.go
+++ b/verify_stream.go
@@ -31,16 +31,6 @@ func newVerifyStream(versionValidator VersionValidator, r io.Reader, msgType Mes
 	return s, nil
 }
 
-func (v *verifyStream) Read(p []byte) (n int, err error) {
-	for n == 0 && err == nil {
-		n, err = v.read(p)
-	}
-	if err == io.EOF && v.state != stateEndOfStream {
-		err = io.ErrUnexpectedEOF
-	}
-	return n, err
-}
-
 func (v *verifyStream) read(p []byte) (n int, err error) {
 	// Handle the case of a previous error. Just return the error again.
 	if v.err != nil {

--- a/verify_stream.go
+++ b/verify_stream.go
@@ -101,9 +101,20 @@ func (v *verifyStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	// TODO: Ideally, we'd have a test exercising this case.
-	if len(chunk) == 0 && (seqno != 0 || !isFinal) {
-		return nil, ErrUnexpectedEmptyBlock
+	if len(chunk) == 0 {
+		switch v.version.Major {
+		case 1:
+			if !isFinal {
+				return nil, ErrUnexpectedEmptyBlock
+			}
+		case 2:
+			// TODO: Ideally, we'd have a test exercising this case.
+			if seqno != 0 || !isFinal {
+				return nil, ErrUnexpectedEmptyBlock
+			}
+		default:
+			panic(ErrBadVersion{v.version})
+		}
 	}
 
 	if isFinal {

--- a/verify_stream.go
+++ b/verify_stream.go
@@ -39,7 +39,7 @@ func (v *verifyStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	err = checkChunkState(v.header.Version, chunk, seqno, isFinal)
+	err = checkDecodedChunkState(v.header.Version, chunk, seqno, isFinal)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make them read multiple chunks if possible. Also
fix a possible infinite loop if the input buffer is zero-length.

Unify all the check*State functions into one for encoders,
and another for decoders.

Error if an empty block is encountered in V2, except if the
entire message is empty.

Also add comment for assertEndOfStream().