### PR TITLE
Make decryptors consistent with each other

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -49,7 +49,7 @@ func (ds *decryptStream) getNextChunk() ([]byte, error) {
 		return nil, err
 	}
 
-	chunk, err := ds.processEncryptionBlock(ciphertext, authenticators, isFinal, seqno)
+	chunk, err := ds.processBlock(ciphertext, authenticators, isFinal, seqno)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 		return err
 	}
 	header.seqno = seqno
-	err = ds.processEncryptionHeader(&header)
+	err = ds.processHeader(&header)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (ds *decryptStream) tryHiddenReceivers(hdr *EncryptionHeader, ephemeralKey 
 	return nil, nil, -1, nil
 }
 
-func (ds *decryptStream) processEncryptionHeader(hdr *EncryptionHeader) error {
+func (ds *decryptStream) processHeader(hdr *EncryptionHeader) error {
 	if err := hdr.validate(ds.versionValidator); err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func computeMACKeyReceiver(version Version, index uint64, secret BoxSecretKey, p
 	}
 }
 
-func (ds *decryptStream) processEncryptionBlock(ciphertext []byte, authenticators []payloadAuthenticator, isFinal bool, seqno packetSeqno) ([]byte, error) {
+func (ds *decryptStream) processBlock(ciphertext []byte, authenticators []payloadAuthenticator, isFinal bool, seqno packetSeqno) ([]byte, error) {
 
 	blockNum := encryptionBlockNumber(seqno - 1)
 

--- a/decrypt.go
+++ b/decrypt.go
@@ -69,7 +69,7 @@ func (ds *decryptStream) getNextChunk() ([]byte, error) {
 func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 	// Read the header bytes.
 	headerBytes := []byte{}
-	seqno, err := ds.mps.Read(&headerBytes)
+	_, err := ds.mps.Read(&headerBytes)
 	if err != nil {
 		return ErrFailedToReadHeaderBytes
 	}
@@ -81,7 +81,6 @@ func (ds *decryptStream) readHeader(rawReader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	header.seqno = seqno
 	err = ds.processHeader(&header)
 	if err != nil {
 		return err

--- a/packets.go
+++ b/packets.go
@@ -38,7 +38,6 @@ type EncryptionHeader struct {
 	Ephemeral       []byte         `codec:"ephemeral"`
 	SenderSecretbox []byte         `codec:"sendersecretbox"`
 	Receivers       []receiverKeys `codec:"rcvrs"`
-	seqno           packetSeqno
 }
 
 // encryptionBlockV1 contains a block of encrypted data. It contains

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -67,7 +67,7 @@ func (sos *signcryptOpenStream) readHeader() error {
 		return err
 	}
 	header.seqno = seqno
-	err = sos.processSigncryptionHeader(&header)
+	err = sos.processHeader(&header)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (sos *signcryptOpenStream) trySharedSymmetricKeys(hdr *SigncryptionHeader, 
 	return nil, nil
 }
 
-func (sos *signcryptOpenStream) processSigncryptionHeader(hdr *SigncryptionHeader) error {
+func (sos *signcryptOpenStream) processHeader(hdr *SigncryptionHeader) error {
 	if err := hdr.validate(); err != nil {
 		return err
 	}

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -54,7 +54,7 @@ func (sos *signcryptOpenStream) getNextChunk() ([]byte, error) {
 func (sos *signcryptOpenStream) readHeader() error {
 	// Read the header bytes.
 	headerBytes := []byte{}
-	seqno, err := sos.mps.Read(&headerBytes)
+	_, err := sos.mps.Read(&headerBytes)
 	if err != nil {
 		return ErrFailedToReadHeaderBytes
 	}
@@ -66,7 +66,6 @@ func (sos *signcryptOpenStream) readHeader() error {
 	if err != nil {
 		return err
 	}
-	header.seqno = seqno
 	err = sos.processHeader(&header)
 	if err != nil {
 		return err

--- a/verify_stream.go
+++ b/verify_stream.go
@@ -55,7 +55,7 @@ func (v *verifyStream) readHeader(versionValidator VersionValidator, msgType Mes
 	var headerBytes []byte
 	_, err := v.mps.Read(&headerBytes)
 	if err != nil {
-		return err
+		return ErrFailedToReadHeaderBytes
 	}
 
 	v.headerHash = hashHeader(headerBytes)
@@ -65,10 +65,11 @@ func (v *verifyStream) readHeader(versionValidator VersionValidator, msgType Mes
 	if err != nil {
 		return err
 	}
-	v.header = &header
 	if err := header.validate(versionValidator, msgType); err != nil {
 		return err
 	}
+
+	v.header = &header
 	return nil
 }
 


### PR DESCRIPTION
Rename process*{Header,Block} to process{Header,Block}.

Remove seqno from the last packet type.

Use ErrFailedToReadHeaderBytes consistently.