### PR TITLE
update the encryption and signing specs to reflect the field order we shipped

### DIFF
--- a/specs/saltpack_encryption_v2.md
+++ b/specs/saltpack_encryption_v2.md
@@ -200,12 +200,14 @@ A payload packet is a MessagePack list with these contents:
 
 ```
 [
+    final flag,
     authenticators list,
     payload secretbox,
-    final flag,
 ]
 ```
 
+- The **final flag** is a boolean, true for the final payload packet, and false
+  for all other payload packets.
 - The **authenticators list** contains 32-byte HMAC tags, one for each
   recipient, which authenticate the **payload secretbox** together with the
   message header. These are computed with the **MAC keys** derived from the
@@ -214,8 +216,6 @@ A payload packet is a MessagePack list with these contents:
   plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. The
   nonce is `saltpack_ploadsbNNNNNNNN` where `NNNNNNNN` is the packet number as
   an 8-byte big-endian unsigned integer. The first payload packet is number 0.
-- The **final flag** is a boolean, true for the final payload packet, and false
-  for all other payload packets.
 
 Computing the **MAC keys** is the only step of encrypting a message that
 requires the sender's private key. Thus it's the **authenticators list**,

--- a/specs/saltpack_signing_v2.md
+++ b/specs/saltpack_signing_v2.md
@@ -59,16 +59,16 @@ Payload packets are MessagePack arrays that look like this:
 
 ```
 [
+    final flag,
     signature,
     payload chunk,
-    final flag,
 ]
 ```
 
-- **signature** is a detached NaCl signature, 64 bytes.
-- **payload chunk** is a chunk of the plaintext bytes, max size 1 MB.
 - **final flag** is a boolean, true for the final payload packet, and false for
   all other payload packets.
+- **signature** is a detached NaCl signature, 64 bytes.
+- **payload chunk** is a chunk of the plaintext bytes, max size 1 MB.
 
 To make each signature, the sender first takes the SHA512 hash of the
 concatenation of four values:


### PR DESCRIPTION
The Go msgpack encoder we're using has a counterintuitive order for
struct fields when serializing as arrays. We meant to put the final flag
at the end, but it's actually at the beginning (though not for
signcryption mode). Update the v2 specs to reflect this unfortunate
reality.

r? @mlsteele @akalin-keybase