### PR TITLE
Manually encode V2 blocks as arrays

### DIFF
--- a/packets.go
+++ b/packets.go
@@ -4,8 +4,9 @@
 package saltpack
 
 import (
-	"encoding"
 	"fmt"
+
+	"github.com/keybase/go-codec/codec"
 )
 
 type receiverKeys struct {
@@ -58,16 +59,22 @@ type encryptionBlockV2 struct {
 	IsFinal bool `codec:"final"`
 }
 
-var _ encoding.BinaryMarshaler = encryptionBlockV2{}
-var _ encoding.BinaryUnmarshaler = (*encryptionBlockV2)(nil)
+var _ codec.Selfer = (*encryptionBlockV2)(nil)
 
-func (b encryptionBlockV2) MarshalBinary() (data []byte, err error) {
-	fields := []interface{}{b.IsFinal, b.HashAuthenticators, b.PayloadCiphertext}
-	return nil, nil
+func (b *encryptionBlockV2) CodecEncodeSelf(e *codec.Encoder) {
+	e.MustEncode([]interface{}{
+		b.IsFinal,
+		b.HashAuthenticators,
+		b.PayloadCiphertext,
+	})
 }
 
-func (b *encryptionBlockV2) UnmarshalBinary(data []byte) error {
-	return nil
+func (b *encryptionBlockV2) CodecDecodeSelf(d *codec.Decoder) {
+	d.MustDecode([]interface{}{
+		&b.IsFinal,
+		&b.HashAuthenticators,
+		&b.PayloadCiphertext,
+	})
 }
 
 func (h *EncryptionHeader) validate(versionValidator func(Version) error) error {

--- a/packets.go
+++ b/packets.go
@@ -59,6 +59,10 @@ type encryptionBlockV2 struct {
 	IsFinal bool `codec:"final"`
 }
 
+// Make *encryptionBlockV2 implement codec.Selfer to encode IsFinal
+// first, to preserve the behavior noticed in this issue:
+// https://github.com/keybase/saltpack/pull/43 .
+
 var _ codec.Selfer = (*encryptionBlockV2)(nil)
 
 func (b *encryptionBlockV2) CodecEncodeSelf(e *codec.Encoder) {

--- a/packets.go
+++ b/packets.go
@@ -171,3 +171,25 @@ type signatureBlockV2 struct {
 	signatureBlockV1
 	IsFinal bool `codec:"final"`
 }
+
+// Make *signatureBlockV2 implement codec.Selfer to encode IsFinal
+// first, to preserve the behavior noticed in this issue:
+// https://github.com/keybase/saltpack/pull/43 .
+
+var _ codec.Selfer = (*signatureBlockV2)(nil)
+
+func (b *signatureBlockV2) CodecEncodeSelf(e *codec.Encoder) {
+	e.MustEncode([]interface{}{
+		b.IsFinal,
+		b.Signature,
+		b.PayloadChunk,
+	})
+}
+
+func (b *signatureBlockV2) CodecDecodeSelf(d *codec.Decoder) {
+	d.MustDecode([]interface{}{
+		&b.IsFinal,
+		&b.Signature,
+		&b.PayloadChunk,
+	})
+}

--- a/packets.go
+++ b/packets.go
@@ -3,7 +3,10 @@
 
 package saltpack
 
-import "fmt"
+import (
+	"encoding"
+	"fmt"
+)
 
 type receiverKeys struct {
 	_struct       bool   `codec:",toarray"`
@@ -53,6 +56,18 @@ type encryptionBlockV1 struct {
 type encryptionBlockV2 struct {
 	encryptionBlockV1
 	IsFinal bool `codec:"final"`
+}
+
+var _ encoding.BinaryMarshaler = encryptionBlockV2{}
+var _ encoding.BinaryUnmarshaler = (*encryptionBlockV2)(nil)
+
+func (b encryptionBlockV2) MarshalBinary() (data []byte, err error) {
+	fields := []interface{}{b.IsFinal, b.HashAuthenticators, b.PayloadCiphertext}
+	return nil, nil
+}
+
+func (b *encryptionBlockV2) UnmarshalBinary(data []byte) error {
+	return nil
 }
 
 func (h *EncryptionHeader) validate(versionValidator func(Version) error) error {

--- a/packets_test.go
+++ b/packets_test.go
@@ -23,12 +23,21 @@ func TestEncryptedBlockV2RoundTrip(t *testing.T) {
 		IsFinal: isFinal,
 	}
 
-	blockV2Bytes, err := encodeToBytes(blockV2)
+	blockV2Bytes1, err := blockV2.MarshalBinary()
 	require.NoError(t, err)
 
-	var blockV2Decoded encryptionBlockV2
-	decodeFromBytes(&blockV2Decoded, blockV2Bytes)
+	blockV2Bytes2, err := encodeToBytes(blockV2)
+	require.NoError(t, err)
 
+	require.Equal(t, blockV2Bytes1, blockV2Bytes2)
+
+	var blockV2Unmarshalled encryptionBlockV2
+	err = blockV2Unmarshalled.UnmarshalBinary(blockV2Bytes1)
+	require.NoError(t, err)
+	require.Equal(t, blockV2, blockV2Unmarshalled)
+
+	var blockV2Decoded encryptionBlockV2
+	decodeFromBytes(&blockV2Decoded, blockV2Bytes1)
 	require.Equal(t, blockV2, blockV2Decoded)
 }
 

--- a/packets_test.go
+++ b/packets_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test that the encoded field order for encryptionBlockV2 puts
+// IsFinal first.
 func TestEncryptedBlockV2Serialization(t *testing.T) {
 	isFinal := true
 	hashAuthenticators := []payloadAuthenticator{{0x1}, {0x2}}

--- a/packets_test.go
+++ b/packets_test.go
@@ -75,3 +75,69 @@ func TestEncryptionBlockV2FieldOrder(t *testing.T) {
 
 	require.Equal(t, blockV2, blockV2Decoded)
 }
+
+// Test that signatureBlockV2 encodes and decodes properly.
+func TestSignatureBlockV2RoundTrip(t *testing.T) {
+	isFinal := false
+	signature := []byte("TestSignatureBlockV2RoundTrip signature")
+	payloadChunk := []byte("TestSignatureBlockV2RoundTrip payload")
+
+	blockV2 := signatureBlockV2{
+		signatureBlockV1: signatureBlockV1{
+			Signature:    signature,
+			PayloadChunk: payloadChunk,
+		},
+		IsFinal: isFinal,
+	}
+
+	// h := codecHandle()
+
+	/*	var blockV2Bytes1 []byte
+		encoder := codec.NewEncoderBytes(&blockV2Bytes1, h)
+		blockV2.CodecEncodeSelf(encoder) */
+
+	blockV2Bytes1, err := encodeToBytes(blockV2)
+	require.NoError(t, err)
+
+	//	require.Equal(t, blockV2Bytes1, blockV2Bytes2)
+
+	/*var blockV2Decoded1 signatureBlockV2
+	decoder := codec.NewDecoderBytes(blockV2Bytes1, h)
+	blockV2Decoded1.CodecDecodeSelf(decoder)
+	require.Equal(t, blockV2, blockV2Decoded1) */
+
+	var blockV2Decoded2 signatureBlockV2
+	err = decodeFromBytes(&blockV2Decoded2, blockV2Bytes1)
+	require.NoError(t, err)
+
+	require.Equal(t, blockV2, blockV2Decoded2)
+}
+
+// Test that the encoded field order for signatureBlockV2 puts
+// IsFinal first.
+func TestSignatureBlockV2FieldOrder(t *testing.T) {
+	isFinal := true
+	signature := []byte("TestSignatureBlockV2FieldOrder signature")
+	payloadChunk := []byte("TestSignatureBlockV2FieldOrder payload")
+
+	blockV2 := signatureBlockV2{
+		signatureBlockV1: signatureBlockV1{
+			Signature:    signature,
+			PayloadChunk: payloadChunk,
+		},
+		IsFinal: isFinal,
+	}
+
+	blockV2Bytes, err := encodeToBytes(blockV2)
+	require.NoError(t, err)
+
+	var blockV2Decoded signatureBlockV2
+	err = decodeFromBytes([]interface{}{
+		&blockV2Decoded.IsFinal,
+		&blockV2Decoded.Signature,
+		&blockV2Decoded.PayloadChunk,
+	}, blockV2Bytes)
+	require.NoError(t, err)
+
+	require.Equal(t, blockV2, blockV2Decoded)
+}

--- a/packets_test.go
+++ b/packets_test.go
@@ -1,0 +1,33 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptedBlockV2Serialization(t *testing.T) {
+	isFinal := true
+	hashAuthenticators := []payloadAuthenticator{{0x1}, {0x2}}
+	payloadCiphertext := []byte("some ciphertext")
+
+	blockV2 := encryptionBlockV2{
+		encryptionBlockV1: encryptionBlockV1{
+			HashAuthenticators: hashAuthenticators,
+			PayloadCiphertext:  payloadCiphertext,
+		},
+		IsFinal: isFinal,
+	}
+
+	blockV2Bytes, err := encodeToBytes(blockV2)
+	require.NoError(t, err)
+
+	blockV2Fields := []interface{}{isFinal, hashAuthenticators, payloadCiphertext}
+	expectedBytes, err := encodeToBytes(blockV2Fields)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedBytes, blockV2Bytes)
+}

--- a/packets_test.go
+++ b/packets_test.go
@@ -9,12 +9,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test that encryptedBlockV2 encodes and decodes properly.
+func TestEncryptedBlockV2RoundTrip(t *testing.T) {
+	isFinal := false
+	hashAuthenticators := []payloadAuthenticator{{0x1}, {0x2}}
+	payloadCiphertext := []byte("TestEncryptedBlockV2RoundTrip")
+
+	blockV2 := encryptionBlockV2{
+		encryptionBlockV1: encryptionBlockV1{
+			HashAuthenticators: hashAuthenticators,
+			PayloadCiphertext:  payloadCiphertext,
+		},
+		IsFinal: isFinal,
+	}
+
+	blockV2Bytes, err := encodeToBytes(blockV2)
+	require.NoError(t, err)
+
+	var blockV2Decoded encryptionBlockV2
+	decodeFromBytes(&blockV2Decoded, blockV2Bytes)
+
+	require.Equal(t, blockV2, blockV2Decoded)
+}
+
 // Test that the encoded field order for encryptionBlockV2 puts
 // IsFinal first.
-func TestEncryptedBlockV2Serialization(t *testing.T) {
+func TestEncryptedBlockV2FieldOrder(t *testing.T) {
 	isFinal := true
-	hashAuthenticators := []payloadAuthenticator{{0x1}, {0x2}}
-	payloadCiphertext := []byte("some ciphertext")
+	hashAuthenticators := []payloadAuthenticator{{0x3}, {0x4}}
+	payloadCiphertext := []byte("TestEncryptedBlockV2FieldOrder")
 
 	blockV2 := encryptionBlockV2{
 		encryptionBlockV1: encryptionBlockV1{

--- a/packets_test.go
+++ b/packets_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test that encryptedBlockV2 encodes and decodes properly.
-func TestEncryptedBlockV2RoundTrip(t *testing.T) {
+// Test that encryptionBlockV2 encodes and decodes properly.
+func TestEncryptionBlockV2RoundTrip(t *testing.T) {
 	isFinal := false
 	hashAuthenticators := []payloadAuthenticator{{0x1}, {0x2}}
-	payloadCiphertext := []byte("TestEncryptedBlockV2RoundTrip")
+	payloadCiphertext := []byte("TestEncryptionBlockV2RoundTrip")
 
 	blockV2 := encryptionBlockV2{
 		encryptionBlockV1: encryptionBlockV1{
@@ -49,10 +49,10 @@ func TestEncryptedBlockV2RoundTrip(t *testing.T) {
 
 // Test that the encoded field order for encryptionBlockV2 puts
 // IsFinal first.
-func TestEncryptedBlockV2FieldOrder(t *testing.T) {
+func TestEncryptionBlockV2FieldOrder(t *testing.T) {
 	isFinal := true
 	hashAuthenticators := []payloadAuthenticator{{0x3}, {0x4}}
-	payloadCiphertext := []byte("TestEncryptedBlockV2FieldOrder")
+	payloadCiphertext := []byte("TestEncryptionBlockV2FieldOrder")
 
 	blockV2 := encryptionBlockV2{
 		encryptionBlockV1: encryptionBlockV1{

--- a/packets_test.go
+++ b/packets_test.go
@@ -6,6 +6,7 @@ package saltpack
 import (
 	"testing"
 
+	"github.com/keybase/go-codec/codec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,22 +24,25 @@ func TestEncryptedBlockV2RoundTrip(t *testing.T) {
 		IsFinal: isFinal,
 	}
 
-	blockV2Bytes1, err := blockV2.MarshalBinary()
-	require.NoError(t, err)
+	h := codecHandle()
+
+	var blockV2Bytes1 []byte
+	encoder := codec.NewEncoderBytes(&blockV2Bytes1, h)
+	blockV2.CodecEncodeSelf(encoder)
 
 	blockV2Bytes2, err := encodeToBytes(blockV2)
 	require.NoError(t, err)
 
 	require.Equal(t, blockV2Bytes1, blockV2Bytes2)
 
-	var blockV2Unmarshalled encryptionBlockV2
-	err = blockV2Unmarshalled.UnmarshalBinary(blockV2Bytes1)
-	require.NoError(t, err)
-	require.Equal(t, blockV2, blockV2Unmarshalled)
+	var blockV2Decoded1 encryptionBlockV2
+	decoder := codec.NewDecoderBytes(blockV2Bytes1, h)
+	blockV2Decoded1.CodecDecodeSelf(decoder)
+	require.Equal(t, blockV2, blockV2Decoded1)
 
-	var blockV2Decoded encryptionBlockV2
-	decodeFromBytes(&blockV2Decoded, blockV2Bytes1)
-	require.Equal(t, blockV2, blockV2Decoded)
+	var blockV2Decoded2 encryptionBlockV2
+	decodeFromBytes(&blockV2Decoded2, blockV2Bytes1)
+	require.Equal(t, blockV2, blockV2Decoded2)
 }
 
 // Test that the encoded field order for encryptionBlockV2 puts

--- a/packets_test.go
+++ b/packets_test.go
@@ -90,21 +90,21 @@ func TestSignatureBlockV2RoundTrip(t *testing.T) {
 		IsFinal: isFinal,
 	}
 
-	// h := codecHandle()
+	h := codecHandle()
 
-	/*	var blockV2Bytes1 []byte
-		encoder := codec.NewEncoderBytes(&blockV2Bytes1, h)
-		blockV2.CodecEncodeSelf(encoder) */
+	var blockV2Bytes1 []byte
+	encoder := codec.NewEncoderBytes(&blockV2Bytes1, h)
+	blockV2.CodecEncodeSelf(encoder)
 
-	blockV2Bytes1, err := encodeToBytes(blockV2)
+	blockV2Bytes2, err := encodeToBytes(blockV2)
 	require.NoError(t, err)
 
-	//	require.Equal(t, blockV2Bytes1, blockV2Bytes2)
+	require.Equal(t, blockV2Bytes1, blockV2Bytes2)
 
-	/*var blockV2Decoded1 signatureBlockV2
+	var blockV2Decoded1 signatureBlockV2
 	decoder := codec.NewDecoderBytes(blockV2Bytes1, h)
 	blockV2Decoded1.CodecDecodeSelf(decoder)
-	require.Equal(t, blockV2, blockV2Decoded1) */
+	require.Equal(t, blockV2, blockV2Decoded1)
 
 	var blockV2Decoded2 signatureBlockV2
 	err = decodeFromBytes(&blockV2Decoded2, blockV2Bytes1)

--- a/packets_test.go
+++ b/packets_test.go
@@ -41,7 +41,9 @@ func TestEncryptedBlockV2RoundTrip(t *testing.T) {
 	require.Equal(t, blockV2, blockV2Decoded1)
 
 	var blockV2Decoded2 encryptionBlockV2
-	decodeFromBytes(&blockV2Decoded2, blockV2Bytes1)
+	err = decodeFromBytes(&blockV2Decoded2, blockV2Bytes1)
+	require.NoError(t, err)
+
 	require.Equal(t, blockV2, blockV2Decoded2)
 }
 
@@ -63,9 +65,13 @@ func TestEncryptedBlockV2FieldOrder(t *testing.T) {
 	blockV2Bytes, err := encodeToBytes(blockV2)
 	require.NoError(t, err)
 
-	blockV2Fields := []interface{}{isFinal, hashAuthenticators, payloadCiphertext}
-	expectedBytes, err := encodeToBytes(blockV2Fields)
+	var blockV2Decoded encryptionBlockV2
+	err = decodeFromBytes([]interface{}{
+		&blockV2Decoded.IsFinal,
+		&blockV2Decoded.HashAuthenticators,
+		&blockV2Decoded.PayloadCiphertext,
+	}, blockV2Bytes)
 	require.NoError(t, err)
 
-	require.Equal(t, expectedBytes, blockV2Bytes)
+	require.Equal(t, blockV2, blockV2Decoded)
 }


### PR DESCRIPTION
This makes it so that we can update to upstream go-codec while
preserving the field order.

See discussion on https://github.com/keybase/saltpack/pull/43 .