### PR TITLE
Relax error checking to work with upstream codec package

### DIFF
--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -73,26 +73,18 @@ func testBadArmor62(t *testing.T, version Version) {
 	_, ciphertext := encryptArmor62RandomData(t, version, 24)
 	bad1 := ciphertext[0:2] + "䁕" + ciphertext[2:]
 	_, _, _, err := Dearmor62DecryptOpen(SingleVersionValidator(version), bad1, kr)
-	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted error type %T but got type %T", ErrBadFrame{}, err)
-	}
+	require.IsType(t, ErrBadFrame{}, err)
 	_, _, _, err = Armor62Open(bad1)
-	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted error type %T but got type %T", ErrBadFrame{}, err)
-	}
+	require.IsType(t, ErrBadFrame{}, err)
 
 	bad2 := ciphertext[0:1] + "z" + ciphertext[2:]
 	_, _, _, err = Dearmor62DecryptOpen(SingleVersionValidator(version), bad2, kr)
-	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted error of type ErrBadFrame; got %v", err)
-	}
+	require.IsType(t, ErrBadFrame{}, err)
 
 	l := len(ciphertext)
 	bad3 := ciphertext[0:(l-8)] + "z" + ciphertext[(l-7):]
 	_, _, _, err = Dearmor62DecryptOpen(SingleVersionValidator(version), bad3, kr)
-	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted error of type ErrBadFrame; got %v", err)
-	}
+	require.IsType(t, ErrBadFrame{}, err)
 
 	bad4 := ciphertext + "䁕"
 	_, _, _, err = Dearmor62DecryptOpen(SingleVersionValidator(version), bad4, kr)
@@ -100,15 +92,11 @@ func testBadArmor62(t *testing.T, version Version) {
 
 	bad5 := ciphertext[0:(l-8)] + "䁕" + ciphertext[(l-7):]
 	_, _, _, err = Armor62Open(bad5)
-	if _, ok := err.(ErrBadFrame); !ok {
-		t.Fatalf("Wanted error type %T but got type %T", ErrBadFrame{}, err)
-	}
+	require.IsType(t, ErrBadFrame{}, err)
 	half := l >> 1
 	bad6 := ciphertext[0:half] + "䁕" + ciphertext[(half+1):]
 	_, _, _, err = Armor62Open(bad6)
-	if _, ok := err.(basex.CorruptInputError); !ok {
-		t.Fatalf("Wanted error of type CorruptInputError but got %v", err)
-	}
+	require.IsType(t, basex.CorruptInputError(0), err)
 }
 
 func TestArmor62Encrypt(t *testing.T) {

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -78,7 +78,7 @@ func testNewlineInFrame(t *testing.T, version Version) {
 	plaintext, ciphertext := encryptArmor62RandomData(t, version, 1024)
 
 	//newline space space tab space
-	ss := []string{"\n\n>   ", ciphertext[0:10], "\n  	 ", ciphertext[11:]}
+	ss := []string{"\n\n>   ", ciphertext[0:10], "\n	 ", ciphertext[11:]}
 	ciphertext = strings.Join(ss, "")
 
 	_, plaintext2, brand, err := Dearmor62DecryptOpen(SingleVersionValidator(version), ciphertext, kr)
@@ -118,9 +118,7 @@ func testBadArmor62(t *testing.T, version Version) {
 
 	bad4 := ciphertext + "䁕"
 	_, _, _, err = Dearmor62DecryptOpen(SingleVersionValidator(version), bad4, kr)
-	if err != ErrTrailingGarbage {
-		t.Fatalf("Wanted error %v but got %v", ErrTrailingGarbage, err)
-	}
+	requireErrSuffix(t, err, ErrTrailingGarbage.Error())
 
 	bad5 := ciphertext[0:(l-8)] + "䁕" + ciphertext[(l-7):]
 	_, _, _, err = Armor62Open(bad5)

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -60,7 +60,7 @@ func testNewlineInFrame(t *testing.T, version Version) {
 	plaintext, ciphertext := encryptArmor62RandomData(t, version, 1024)
 
 	//newline space space tab space
-	ss := []string{"\n\n>   ", ciphertext[0:10], "\n	 ", ciphertext[11:]}
+	ss := []string{"\n\n>   ", ciphertext[0:10], "\n  	 ", ciphertext[11:]}
 	ciphertext = strings.Join(ss, "")
 
 	_, plaintext2, brand, err := Dearmor62DecryptOpen(SingleVersionValidator(version), ciphertext, kr)

--- a/armor_test.go
+++ b/armor_test.go
@@ -27,9 +27,8 @@ func msg(sz int) []byte {
 const ourBrand = "ACME"
 
 func brandCheck(t *testing.T, received string) {
-	if received != ourBrand {
-		t.Fatalf("brand mismatch; wanted %q but got %q", ourBrand, received)
-	}
+	t.Helper()
+	require.Equal(t, ourBrand, received)
 }
 
 const hdr = "BEGIN ACME SALTPACK ENCRYPTED MESSAGE"

--- a/armor_test.go
+++ b/armor_test.go
@@ -36,23 +36,13 @@ const ftr = "END ACME SALTPACK ENCRYPTED MESSAGE"
 
 func testArmor(t *testing.T, sz int) {
 	m := msg(sz)
-	a, e := Armor62Seal(m, MessageTypeEncryption, ourBrand)
-	if e != nil {
-		t.Fatal(e)
-	}
+	a, err := Armor62Seal(m, MessageTypeEncryption, ourBrand)
+	require.NoError(t, err)
 	m2, hdr2, ftr2, err := Armor62Open(a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(m, m2) {
-		t.Errorf("Buffers disagreed: %v != %v (%d v %d)", m, m2, len(m), len(m2))
-	}
-	if hdr != hdr2 {
-		t.Errorf("headers disagreed: %s != %s", hdr, hdr2)
-	}
-	if ftr != ftr2 {
-		t.Errorf("headers disagreed: %s != %s", ftr, ftr2)
-	}
+	require.NoError(t, err)
+	require.Equal(t, m, m2)
+	require.Equal(t, hdr, hdr2)
+	require.Equal(t, ftr, ftr2)
 }
 
 func TestArmor128(t *testing.T) {
@@ -78,30 +68,18 @@ func TestSlowWriter(t *testing.T) {
 	m := msg(1024 * 16)
 	var out bytes.Buffer
 	enc, err := NewArmor62EncoderStream(&out, MessageTypeEncryption, ourBrand)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, c := range m {
-		if _, err = enc.Write([]byte{c}); err != nil {
-			t.Fatal(err)
-		}
+		_, err = enc.Write([]byte{c})
+		require.NoError(t, err)
 	}
-	if err = enc.Close(); err != nil {
-		t.Fatal(err)
-	}
+	err = enc.Close()
+	require.NoError(t, err)
 	m2, hdr2, ftr2, err := Armor62Open(out.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(m, m2) {
-		t.Fatal("Buffer mismatch")
-	}
-	if ftr != ftr2 {
-		t.Fatal("footer mismatch")
-	}
-	if hdr != hdr2 {
-		t.Fatal("header mismatch")
-	}
+	require.NoError(t, err)
+	require.Equal(t, m, m2)
+	require.Equal(t, hdr, hdr2)
+	require.Equal(t, ftr, ftr2)
 }
 
 type slowReader struct {

--- a/armor_test.go
+++ b/armor_test.go
@@ -99,42 +99,24 @@ func TestSlowReader(t *testing.T) {
 	var sr slowReader
 	m := msg(1024 * 32)
 	a, err := Armor62Seal(m, MessageTypeEncryption, ourBrand)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sr.buf = []byte(a)
 	dec, frame, err := NewArmor62DecoderStream(&sr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	m2, err := ioutil.ReadAll(dec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(m, m2) {
-		t.Fatalf("buffer mismatch")
-	}
+	require.NoError(t, err)
+	require.Equal(t, m, m2)
 	hdr2, err := frame.GetHeader()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if hdr != hdr2 {
-		t.Fatalf("header mismatch: %s != %s", hdr, hdr2)
-	}
+	require.NoError(t, err)
+	require.Equal(t, hdr, hdr2)
 	ftr2, err := frame.GetFooter()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ftr != ftr2 {
-		t.Fatalf("footer mismatch: %s != %s", ftr, ftr2)
-	}
+	require.NoError(t, err)
+	require.Equal(t, ftr, ftr2)
 }
 
 func TestBinaryInput(t *testing.T) {
 	in, err := hex.DecodeString("96a873616c747061636b92010002c420c4afc00d50af5072094609199b54a5f8cf7b03bcea3d4945b2bbd50ac1cd42ecc41014bf77454c0b028cb009d06019981a75c4401a451af65fa3b40ae2be73b5c17dc2657992337c98ad75d4fe21de37fba2329b4970defbea176c98d306d0d285ffaa515b630224836b2c55ba1b6ba026a62102")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	done := make(chan bool)
 	var m []byte

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -21,15 +21,11 @@ func TestDecryptVersionValidator(t *testing.T) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	ciphertext, err := Seal(Version1(), plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = Open(SingleVersionValidator(Version2()), ciphertext, kr)
 	expectedErr := ErrBadVersion{Version1()}
-	if err != expectedErr {
-		t.Fatalf("expected %v, got %v", expectedErr, err)
-	}
+	require.Equal(t, expectedErr, err)
 }
 
 func testDecryptNewMinorVersion(t *testing.T, version Version) {
@@ -46,14 +42,10 @@ func testDecryptNewMinorVersion(t *testing.T, version Version) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	ciphertext, err := testSeal(version, plaintext, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = Open(SingleVersionValidator(newVersion), ciphertext, kr)
-	if err != nil {
-		t.Fatalf("Unepected error %v", err)
-	}
+	require.NoError(t, err)
 }
 
 type errAtEOFReader struct {
@@ -74,26 +66,20 @@ func testDecryptErrorAtEOF(t *testing.T, version Version) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var reader io.Reader = bytes.NewReader(ciphertext)
 	errAtEOF := errors.New("err at EOF")
 	reader = errAtEOFReader{reader, errAtEOF}
 	_, stream, err := NewDecryptStream(SingleVersionValidator(version), reader, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	msg, err := ioutil.ReadAll(stream)
 	requireErrSuffix(t, err, errAtEOF.Error())
 
 	// Since the bytes are still authenticated, the decrypted
 	// message should still compare equal to the original input.
-	if !bytes.Equal(msg, plaintext) {
-		t.Errorf("decrypted msg '%x', expected '%x'", msg, plaintext)
-	}
+	require.Equal(t, plaintext, msg)
 }
 
 func TestDecrypt(t *testing.T) {

--- a/decrypt_test.go
+++ b/decrypt_test.go
@@ -87,9 +87,7 @@ func testDecryptErrorAtEOF(t *testing.T, version Version) {
 	}
 
 	msg, err := ioutil.ReadAll(stream)
-	if err != errAtEOF {
-		t.Fatalf("err=%v != errAtEOF=%v", err, errAtEOF)
-	}
+	requireErrSuffix(t, err, errAtEOF.Error())
 
 	// Since the bytes are still authenticated, the decrypted
 	// message should still compare equal to the original input.

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1306,9 +1306,7 @@ func TestEncryptSubsequenceV1(t *testing.T) {
 
 	encode := func(e encoder, i interface{}) {
 		err = e.Encode(i)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	var headerBytes []byte
@@ -1380,9 +1378,7 @@ func TestEncryptSubsequenceV2(t *testing.T) {
 
 	encode := func(e encoder, i interface{}) {
 		err = e.Encode(i)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 
 	var headerBytes []byte

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -478,15 +478,11 @@ func testTruncation(t *testing.T, version Version) {
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	strm, err := newTestEncryptStream(version, &out, sndr, receivers,
 		testEncryptionOptions{blockSize: 1024})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := strm.Write(msg); err != nil {
-		t.Fatal(err)
-	}
-	if err := strm.Close(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	_, err = strm.Write(msg)
+	require.NoError(t, err)
+	err = strm.Close()
+	require.NoError(t, err)
 
 	ciphertext := out.Bytes()
 	trunced1 := ciphertext[0 : len(ciphertext)-51]
@@ -498,25 +494,22 @@ func testTruncation(t *testing.T, version Version) {
 
 func testMediumEncryptionOneReceiverSmallReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	if _, err := rand.Read(buf); err != nil {
-		t.Fatal(err)
-	}
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 1})
 }
 
 func testMediumEncryptionOneReceiverSmallishReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	if _, err := rand.Read(buf); err != nil {
-		t.Fatal(err)
-	}
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 7})
 }
 
 func testMediumEncryptionOneReceiverMediumReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	if _, err := rand.Read(buf); err != nil {
-		t.Fatal(err)
-	}
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 79})
 }
 
@@ -528,13 +521,9 @@ func testSealAndOpen(t *testing.T, version Version, sz int) {
 		t.Fatal(err)
 	}
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, plaintext2, err := Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !bytes.Equal(plaintext, plaintext2) {
 		t.Fatal("decryption mismatch")
 	}
@@ -559,13 +548,9 @@ func testSealAndOpenTwoReceivers(t *testing.T, version Version) {
 		t.Fatal(err)
 	}
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, plaintext2, err := Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !bytes.Equal(plaintext, plaintext2) {
 		t.Fatal("decryption mismatch")
 	}
@@ -604,9 +589,7 @@ func testCorruptHeaderNonce(t *testing.T, version Version) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
@@ -637,9 +620,7 @@ func testCorruptHeaderNonceR5(t *testing.T, version Version) {
 		newBoxKeyNoInsert(t).GetPublicKey(),
 	}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
@@ -658,13 +639,9 @@ func testCorruptHeaderNonceR5(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func testCorruptPayloadKeyBoxR5(t *testing.T, version Version) {
@@ -688,9 +665,7 @@ func testCorruptPayloadKeyBoxR5(t *testing.T, version Version) {
 		newBoxKeyNoInsert(t).GetPublicKey(),
 	}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
@@ -706,13 +681,9 @@ func testCorruptPayloadKeyBoxR5(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
@@ -735,9 +706,7 @@ func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
 	}
 
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// If we've corrupted the payload key, the first thing that will fail is
 	// opening the sender secretbox.
@@ -755,9 +724,7 @@ func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrBadSymmetricKey {
 		t.Fatalf("Got wrong error; wanted 'Bad Symmetric Key' but got %v", err)
@@ -772,9 +739,7 @@ func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
 		sender.GetPublicKey(),
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, iterableKeyring)
 	if err != ErrBadSymmetricKey {
 		t.Fatalf("Got wrong error; wanted 'Bad Symmetric Key' but got %v", err)
@@ -798,9 +763,7 @@ func testCorruptSenderSecretboxPlaintext(t *testing.T, version Version) {
 		newBoxKeyNoInsert(t).GetPublicKey(),
 	}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if mm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Tag' but got %v", err)
@@ -818,9 +781,7 @@ func testCorruptSenderSecretboxPlaintext(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrBadBoxKey {
 		t.Fatalf("Got wrong error; wanted 'Bad Sender Key' but got %v", err)
@@ -843,9 +804,7 @@ func testCorruptSenderSecretboxCiphertext(t *testing.T, version Version) {
 		newBoxKeyNoInsert(t).GetPublicKey(),
 	}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrBadSenderKeySecretbox {
 		t.Fatalf("Got wrong error; wanted 'Bad Sender Key Secretbox' but got %v", err)
@@ -860,9 +819,7 @@ func testMissingFooter(t *testing.T, version Version) {
 		skipFooter: true,
 		blockSize:  1024,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != io.ErrUnexpectedEOF {
 		t.Fatalf("Wanted %v but got %v", io.ErrUnexpectedEOF, err)
@@ -895,9 +852,7 @@ func testCorruptEncryption(t *testing.T, version Version) {
 			}
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if mm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
@@ -915,9 +870,7 @@ func testCorruptEncryption(t *testing.T, version Version) {
 			}
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if mm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Tag; failed Poly1305' but got %v", err)
@@ -939,9 +892,7 @@ func testCorruptEncryption(t *testing.T, version Version) {
 			return n
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if emm, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Expected a 'bad tag' error but got %v", err)
@@ -961,9 +912,7 @@ func testCorruptButAuthenticPayloadBox(t *testing.T, version Version) {
 			}
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if emm, ok := err.(ErrBadCiphertext); !ok {
 		t.Fatalf("Expected a 'bad ciphertext' error but got %v", err)
@@ -988,9 +937,7 @@ func testCorruptNonce(t *testing.T, version Version) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if bcte, ok := err.(ErrBadTag); !ok {
 		t.Fatalf("Wanted error 'ErrBadTag' but got %v", err)
@@ -1015,9 +962,7 @@ func testCorruptHeader(t *testing.T, version Version) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if ebv, ok := err.(ErrBadVersion); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
@@ -1033,9 +978,7 @@ func testCorruptHeader(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if ebv, ok := err.(ErrWrongMessageType); !ok {
 		t.Fatalf("Got wrong error; wanted 'Bad Type' but got %v", err)
@@ -1056,9 +999,7 @@ func testCorruptHeader(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	requireErrSuffix(t, err, "only encoded map or array can be decoded into a struct")
 }
@@ -1070,9 +1011,7 @@ func testNoSenderKey(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, testEncryptionOptions{
 		blockSize: 1024,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrNoSenderKey {
 		t.Fatalf("Wanted %v but got %v", ErrNoSenderKey, err)
@@ -1084,9 +1023,7 @@ func testSealAndOpenTrailingGarbage(t *testing.T, version Version) {
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	plaintext := randomMsg(t, 1024*3)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var buf bytes.Buffer
 	buf.Write(ciphertext)
 	newEncoder(&buf).Encode(randomMsg(t, 14))
@@ -1100,13 +1037,9 @@ func testAnonymousSender(t *testing.T, version Version) {
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	plaintext := randomMsg(t, 1024*3)
 	ciphertext, err := Seal(version, plaintext, nil, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func testAllAnonymous(t *testing.T, version Version) {
@@ -1122,9 +1055,7 @@ func testAllAnonymous(t *testing.T, version Version) {
 	}
 	plaintext := randomMsg(t, 1024*3)
 	ciphertext, err := Seal(version, plaintext, nil, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrNoDecryptionKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
@@ -1132,9 +1063,7 @@ func testAllAnonymous(t *testing.T, version Version) {
 
 	var mki *MessageKeyInfo
 	mki, _, err = Open(SingleVersionValidator(version), ciphertext, kr.makeIterable())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !mki.SenderIsAnon {
 		t.Fatal("sender should be anon")
 	}
@@ -1153,9 +1082,7 @@ func testAllAnonymous(t *testing.T, version Version) {
 
 	receivers[5] = newHiddenBoxKeyNoInsert(t).GetPublicKey()
 	ciphertext, err = Seal(version, plaintext, nil, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	mki, _, err = Open(SingleVersionValidator(version), ciphertext, kr.makeIterable())
 	if err != ErrNoDecryptionKey {
@@ -1186,9 +1113,7 @@ func testCorruptEphemeralKey(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err := testSeal(version, plaintext, nil, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrBadEphemeralKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrBadEphemeralKey)
@@ -1208,9 +1133,7 @@ func testCiphertextSwapKeys(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err := testSeal(version, plaintext, nil, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != errPublicKeyDecryptionFailed {
 		t.Fatalf("Got %v but wanted %v", err, errPublicKeyDecryptionFailed)
@@ -1230,9 +1153,7 @@ func testEmptyReceiverKID(t *testing.T, version Version) {
 		},
 	}
 	ciphertext, err := testSeal(version, plaintext, nil, receivers, teo)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrNoDecryptionKey {
 		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
@@ -1250,13 +1171,9 @@ func testAnonymousThenNamed(t *testing.T, version Version) {
 	}
 	plaintext := randomMsg(t, 1024*3)
 	ciphertext, err := Seal(version, plaintext, nil, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func testBadKeyLookup(t *testing.T, version Version) {
@@ -1270,9 +1187,7 @@ func testBadKeyLookup(t *testing.T, version Version) {
 	}
 	plaintext := randomMsg(t, 1024*3)
 	ciphertext, err := Seal(version, plaintext, nil, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	kr.bad = true
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
 	if err != ErrBadLookup {
@@ -1284,9 +1199,7 @@ func testBadKeyLookup(t *testing.T, version Version) {
 func TestCorruptFraming(t *testing.T) {
 	// Create a "ciphertext" where header packet is a type other than bytes.
 	nonInteger, err := encodeToBytes(42)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, _, err = Open(CheckKnownMajorVersion, nonInteger, kr)
 	if err != ErrFailedToReadHeaderBytes {
 		t.Fatal(err)
@@ -1301,19 +1214,13 @@ func testNoWriteMessage(t *testing.T, version Version) {
 	}
 	var ciphertext bytes.Buffer
 	es, err := NewEncryptStream(version, &ciphertext, nil, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// Usually we would call Write() here. But with an empty message, we don't
 	// have to!
 	err = es.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, plaintext, err := Open(SingleVersionValidator(version), ciphertext.Bytes(), kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if len(plaintext) != 0 {
 		t.Fatal("Expected empty plaintext!")
 	}
@@ -1327,31 +1234,23 @@ func TestEncryptSinglePacketV1(t *testing.T) {
 
 	plaintext := make([]byte, encryptionBlockSize)
 	ciphertext, err := Seal(Version1(), plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	mps := newMsgpackStream(bytes.NewReader(ciphertext))
 
 	var headerBytes []byte
 	_, err = mps.Read(&headerBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var block encryptionBlockV1
 
 	// Payload packet.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Empty footer payload packet.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Nothing else.
 	_, err = mps.Read(&block)
@@ -1368,25 +1267,19 @@ func TestEncryptSinglePacketV2(t *testing.T) {
 
 	plaintext := make([]byte, encryptionBlockSize)
 	ciphertext, err := Seal(Version2(), plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	mps := newMsgpackStream(bytes.NewReader(ciphertext))
 
 	var headerBytes []byte
 	_, err = mps.Read(&headerBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var block encryptionBlockV2
 
 	// Payload packet.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if !block.IsFinal {
 		t.Fatal("IsFinal unexpectedly not set")
@@ -1405,9 +1298,7 @@ func TestEncryptSubsequenceV1(t *testing.T) {
 
 	plaintext := make([]byte, 2*encryptionBlockSize)
 	ciphertext, err := Seal(Version1(), plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	mps := newMsgpackStream(bytes.NewReader(ciphertext))
 
@@ -1430,9 +1321,7 @@ func TestEncryptSubsequenceV1(t *testing.T) {
 
 	var headerBytes []byte
 	_, err = mps.Read(&headerBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	encode(encoder1, headerBytes)
 	encode(encoder2, headerBytes)
@@ -1442,25 +1331,19 @@ func TestEncryptSubsequenceV1(t *testing.T) {
 
 	// Payload packet 1.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	encode(encoder1, block)
 
 	// Payload packet 2.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	encode(encoder2, block)
 
 	// Empty footer payload packet.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	encode(encoder1, block)
 	encode(encoder2, block)
@@ -1492,9 +1375,7 @@ func TestEncryptSubsequenceV2(t *testing.T) {
 
 	plaintext := make([]byte, 2*encryptionBlockSize)
 	ciphertext, err := Seal(Version2(), plaintext, sender, receivers)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	mps := newMsgpackStream(bytes.NewReader(ciphertext))
 
@@ -1514,9 +1395,7 @@ func TestEncryptSubsequenceV2(t *testing.T) {
 
 	var headerBytes []byte
 	_, err = mps.Read(&headerBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	encode(encoder1, headerBytes)
 	encode(encoder2, headerBytes)
@@ -1525,18 +1404,14 @@ func TestEncryptSubsequenceV2(t *testing.T) {
 
 	// Payload packet 1.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	block.IsFinal = true
 	encode(encoder1, block)
 
 	// Payload packet 2.
 	_, err = mps.Read(&block)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	block.IsFinal = true
 	encode(encoder2, block)

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -693,9 +693,7 @@ func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
 	// If we've corrupted the payload key, the first thing that will fail is
 	// opening the sender secretbox.
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrBadSenderKeySecretbox {
-		t.Fatalf("Got wrong error; wanted %v but got %v", ErrBadSenderKeySecretbox, err)
-	}
+	require.Equal(t, ErrBadSenderKeySecretbox, err)
 
 	// Also try truncating the payload key. This should fail with a different
 	// error.
@@ -708,9 +706,7 @@ func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrBadSymmetricKey {
-		t.Fatalf("Got wrong error; wanted 'Bad Symmetric Key' but got %v", err)
-	}
+	require.Equal(t, ErrBadSymmetricKey, err)
 
 	// Finally, do the above test again with a hidden receiver. The default
 	// testing keyring is not iterable, so we need to make a new one.
@@ -723,9 +719,7 @@ func testCorruptPayloadKeyPlaintext(t *testing.T, version Version) {
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, iterableKeyring)
-	if err != ErrBadSymmetricKey {
-		t.Fatalf("Got wrong error; wanted 'Bad Symmetric Key' but got %v", err)
-	}
+	require.Equal(t, ErrBadSymmetricKey, err)
 }
 
 func testCorruptSenderSecretboxPlaintext(t *testing.T, version Version) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -554,9 +554,7 @@ func testRepeatedKey(t *testing.T, version Version) {
 	receivers := []BoxPublicKey{pk, pk}
 	plaintext := randomMsg(t, 1024*3)
 	_, err := Seal(version, plaintext, sender, receivers)
-	if _, ok := err.(ErrRepeatedKey); !ok {
-		t.Fatalf("Wanted a repeated key error; got %v", err)
-	}
+	require.IsType(t, ErrRepeatedKey{}, err)
 }
 
 func testEmptyReceivers(t *testing.T, version Version) {
@@ -564,9 +562,7 @@ func testEmptyReceivers(t *testing.T, version Version) {
 	receivers := []BoxPublicKey{}
 	plaintext := randomMsg(t, 1024*3)
 	_, err := Seal(version, plaintext, sender, receivers)
-	if err != ErrBadReceivers {
-		t.Fatalf("Wanted error %v but got %v", ErrBadReceivers, err)
-	}
+	require.Equal(t, ErrBadReceivers, err)
 }
 
 func testCorruptHeaderNonce(t *testing.T, version Version) {
@@ -583,9 +579,7 @@ func testCorruptHeaderNonce(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != errPublicKeyDecryptionFailed {
-		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
-	}
+	require.Equal(t, errPublicKeyDecryptionFailed, err)
 }
 
 func testCorruptHeaderNonceR5(t *testing.T, version Version) {
@@ -614,9 +608,7 @@ func testCorruptHeaderNonceR5(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != errPublicKeyDecryptionFailed {
-		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
-	}
+	require.Equal(t, errPublicKeyDecryptionFailed, err)
 
 	// If someone else's encryption was tampered with, we don't care and
 	// shouldn't get an error.
@@ -659,9 +651,7 @@ func testCorruptPayloadKeyBoxR5(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != errPublicKeyDecryptionFailed {
-		t.Fatalf("Wanted an error %v; got %v", errPublicKeyDecryptionFailed, err)
-	}
+	require.Equal(t, errPublicKeyDecryptionFailed, err)
 
 	// If someone else's encryption was tampered with, we don't care and
 	// shouldn't get an error.

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1146,9 +1146,7 @@ func testBadKeyLookup(t *testing.T, version Version) {
 	require.NoError(t, err)
 	kr.bad = true
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrBadLookup {
-		t.Fatal(err)
-	}
+	require.Equal(t, ErrBadLookup, err)
 	kr.bad = false
 }
 
@@ -1157,9 +1155,7 @@ func TestCorruptFraming(t *testing.T) {
 	nonInteger, err := encodeToBytes(42)
 	require.NoError(t, err)
 	_, _, err = Open(CheckKnownMajorVersion, nonInteger, kr)
-	if err != ErrFailedToReadHeaderBytes {
-		t.Fatal(err)
-	}
+	require.Equal(t, ErrFailedToReadHeaderBytes, err)
 }
 
 func testNoWriteMessage(t *testing.T, version Version) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -765,9 +765,7 @@ func testCorruptSenderSecretboxPlaintext(t *testing.T, version Version) {
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrBadBoxKey {
-		t.Fatalf("Got wrong error; wanted 'Bad Sender Key' but got %v", err)
-	}
+	require.Equal(t, ErrBadBoxKey, err)
 }
 
 func testCorruptSenderSecretboxCiphertext(t *testing.T, version Version) {
@@ -788,9 +786,7 @@ func testCorruptSenderSecretboxCiphertext(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrBadSenderKeySecretbox {
-		t.Fatalf("Got wrong error; wanted 'Bad Sender Key Secretbox' but got %v", err)
-	}
+	require.Equal(t, ErrBadSenderKeySecretbox, err)
 }
 
 func testMissingFooter(t *testing.T, version Version) {
@@ -803,9 +799,7 @@ func testMissingFooter(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != io.ErrUnexpectedEOF {
-		t.Fatalf("Wanted %v but got %v", io.ErrUnexpectedEOF, err)
-	}
+	require.Equal(t, io.ErrUnexpectedEOF, err)
 }
 
 func getEncryptionBlockV1(eb *interface{}) encryptionBlockV1 {
@@ -995,9 +989,7 @@ func testNoSenderKey(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrNoSenderKey {
-		t.Fatalf("Wanted %v but got %v", ErrNoSenderKey, err)
-	}
+	require.Equal(t, ErrNoSenderKey, err)
 }
 
 func testSealAndOpenTrailingGarbage(t *testing.T, version Version) {
@@ -1010,9 +1002,7 @@ func testSealAndOpenTrailingGarbage(t *testing.T, version Version) {
 	buf.Write(ciphertext)
 	newEncoder(&buf).Encode(randomMsg(t, 14))
 	_, _, err = Open(SingleVersionValidator(version), buf.Bytes(), kr)
-	if err != ErrTrailingGarbage {
-		t.Fatalf("Wanted 'ErrTrailingGarbage' but got %v", err)
-	}
+	require.Equal(t, ErrTrailingGarbage, err)
 }
 
 func testAnonymousSender(t *testing.T, version Version) {
@@ -1039,9 +1029,7 @@ func testAllAnonymous(t *testing.T, version Version) {
 	ciphertext, err := Seal(version, plaintext, nil, receivers)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrNoDecryptionKey {
-		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
-	}
+	require.Equal(t, ErrNoDecryptionKey, err)
 
 	var mki *MessageKeyInfo
 	mki, _, err = Open(SingleVersionValidator(version), ciphertext, kr.makeIterable())
@@ -1067,9 +1055,7 @@ func testAllAnonymous(t *testing.T, version Version) {
 	require.NoError(t, err)
 
 	mki, _, err = Open(SingleVersionValidator(version), ciphertext, kr.makeIterable())
-	if err != ErrNoDecryptionKey {
-		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
-	}
+	require.Equal(t, ErrNoDecryptionKey, err)
 
 	if mki.SenderIsAnon {
 		t.Fatal("that the sender shouldn't be anonymous")
@@ -1097,9 +1083,7 @@ func testCorruptEphemeralKey(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, plaintext, nil, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrBadEphemeralKey {
-		t.Fatalf("Got %v but wanted %v", err, ErrBadEphemeralKey)
-	}
+	require.Equal(t, ErrBadEphemeralKey, err)
 }
 
 func testCiphertextSwapKeys(t *testing.T, version Version) {
@@ -1117,9 +1101,7 @@ func testCiphertextSwapKeys(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, plaintext, nil, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != errPublicKeyDecryptionFailed {
-		t.Fatalf("Got %v but wanted %v", err, errPublicKeyDecryptionFailed)
-	}
+	require.Equal(t, errPublicKeyDecryptionFailed, err)
 }
 
 func testEmptyReceiverKID(t *testing.T, version Version) {
@@ -1137,9 +1119,7 @@ func testEmptyReceiverKID(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, plaintext, nil, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err != ErrNoDecryptionKey {
-		t.Fatalf("Got %v but wanted %v", err, ErrNoDecryptionKey)
-	}
+	require.Equal(t, ErrNoDecryptionKey, err)
 }
 
 func testAnonymousThenNamed(t *testing.T, version Version) {
@@ -1236,9 +1216,7 @@ func TestEncryptSinglePacketV1(t *testing.T) {
 
 	// Nothing else.
 	_, err = mps.Read(&block)
-	if err != io.EOF {
-		t.Fatalf("err=%v != io.EOF", err)
-	}
+	require.Equal(t, io.EOF, err)
 }
 
 func TestEncryptSinglePacketV2(t *testing.T) {
@@ -1269,9 +1247,7 @@ func TestEncryptSinglePacketV2(t *testing.T) {
 
 	// Nothing else.
 	_, err = mps.Read(&block)
-	if err != io.EOF {
-		t.Fatalf("err=%v != io.EOF", err)
-	}
+	require.Equal(t, io.EOF, err)
 }
 
 func TestEncryptSubsequenceV1(t *testing.T) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -741,11 +741,7 @@ func testCorruptSenderSecretboxPlaintext(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if mm, ok := err.(ErrBadTag); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Tag' but got %v", err)
-	} else if int(mm) != 1 {
-		t.Fatalf("Wanted a failure in packet %d but got %d", 1, mm)
-	}
+	require.Equal(t, ErrBadTag(1), err)
 
 	// Also try truncating the sender key. This should hit the bad length
 	// check.
@@ -824,11 +820,7 @@ func testCorruptEncryption(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if mm, ok := err.(ErrBadTag); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Ciphertext' but got %v", err)
-	} else if int(mm) != 3 {
-		t.Fatalf("Wanted a failure in packet %d but got %d", 3, mm)
-	}
+	require.Equal(t, ErrBadTag(3), err)
 
 	// Next check that a corruption of the Poly1305 tags causes a failure
 	ciphertext, err = testSeal(version, msg, sender, receivers, testEncryptionOptions{
@@ -842,11 +834,7 @@ func testCorruptEncryption(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if mm, ok := err.(ErrBadTag); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Tag; failed Poly1305' but got %v", err)
-	} else if int(mm) != 3 {
-		t.Fatalf("Wanted a failure in packet %d but got %d", 3, mm)
-	}
+	require.Equal(t, ErrBadTag(3), err)
 
 	// Next check what happens if we swap nonces for blocks 0 and 1
 	msg = randomMsg(t, 1024*2-1)
@@ -864,11 +852,7 @@ func testCorruptEncryption(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if emm, ok := err.(ErrBadTag); !ok {
-		t.Fatalf("Expected a 'bad tag' error but got %v", err)
-	} else if int(emm) != 1 {
-		t.Fatalf("Wanted error packet %d but got %d", 1, emm)
-	}
+	require.Equal(t, ErrBadTag(1), err)
 }
 
 func testCorruptButAuthenticPayloadBox(t *testing.T, version Version) {
@@ -909,11 +893,7 @@ func testCorruptNonce(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if bcte, ok := err.(ErrBadTag); !ok {
-		t.Fatalf("Wanted error 'ErrBadTag' but got %v", err)
-	} else if int(bcte) != 3 {
-		t.Fatalf("wrong packet; wanted %d but got %d", 3, bcte)
-	}
+	require.Equal(t, ErrBadTag(3), err)
 }
 
 func testCorruptHeader(t *testing.T, version Version) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1108,9 +1108,7 @@ func testCorruptHeader(t *testing.T, version Version) {
 		t.Fatal(err)
 	}
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if err == nil || err.Error() != "only encoded map or array can be decoded into a struct" {
-		t.Fatalf("wanted a msgpack decode error")
-	}
+	requireErrSuffix(t, err, "only encoded map or array can be decoded into a struct")
 }
 
 func testNoSenderKey(t *testing.T, version Version) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -868,11 +868,7 @@ func testCorruptButAuthenticPayloadBox(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if emm, ok := err.(ErrBadCiphertext); !ok {
-		t.Fatalf("Expected a 'bad ciphertext' error but got %v", err)
-	} else if int(emm) != 1 {
-		t.Fatalf("Wanted error packet %d but got %d", 1, emm)
-	}
+	require.Equal(t, ErrBadCiphertext(1), err)
 }
 
 func testCorruptNonce(t *testing.T, version Version) {
@@ -914,11 +910,7 @@ func testCorruptHeader(t *testing.T, version Version) {
 	ciphertext, err := testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if ebv, ok := err.(ErrBadVersion); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Version' but got %v", err)
-	} else if ebv.received != badVersion {
-		t.Fatalf("got wrong version # in error message: %v", ebv.received)
-	}
+	require.Equal(t, ErrBadVersion{received: badVersion}, err)
 
 	// Test bad header Tag
 	teo = testEncryptionOptions{
@@ -930,13 +922,10 @@ func testCorruptHeader(t *testing.T, version Version) {
 	ciphertext, err = testSeal(version, msg, sender, receivers, teo)
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	if ebv, ok := err.(ErrWrongMessageType); !ok {
-		t.Fatalf("Got wrong error; wanted 'Bad Type' but got %v", err)
-	} else if ebv.wanted != MessageTypeEncryption {
-		t.Fatalf("got wrong wanted in error message: %d", ebv.wanted)
-	} else if ebv.received != MessageTypeAttachedSignature {
-		t.Fatalf("got wrong received in error message: %d", ebv.received)
-	}
+	require.Equal(t, ErrWrongMessageType{
+		wanted:   MessageTypeEncryption,
+		received: MessageTypeAttachedSignature,
+	}, err)
 
 	// Corrupt Header after packing
 	teo = testEncryptionOptions{

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -487,9 +487,7 @@ func testTruncation(t *testing.T, version Version) {
 	ciphertext := out.Bytes()
 	trunced1 := ciphertext[0 : len(ciphertext)-51]
 	_, _, err = Open(SingleVersionValidator(version), trunced1, kr)
-	if err != io.ErrUnexpectedEOF {
-		t.Fatalf("Wanted an %v; but got %v", io.ErrUnexpectedEOF, err)
-	}
+	require.Equal(t, io.ErrUnexpectedEOF, err)
 }
 
 func testMediumEncryptionOneReceiverSmallReads(t *testing.T, version Version) {
@@ -517,16 +515,13 @@ func testSealAndOpen(t *testing.T, version Version, sz int) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	plaintext := make([]byte, sz)
-	if _, err := rand.Read(plaintext); err != nil {
-		t.Fatal(err)
-	}
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
 	require.NoError(t, err)
 	_, plaintext2, err := Open(SingleVersionValidator(version), ciphertext, kr)
 	require.NoError(t, err)
-	if !bytes.Equal(plaintext, plaintext2) {
-		t.Fatal("decryption mismatch")
-	}
+	require.Equal(t, plaintext, plaintext2)
 }
 
 func testSealAndOpenSmall(t *testing.T, version Version) {
@@ -544,16 +539,13 @@ func testSealAndOpenTwoReceivers(t *testing.T, version Version) {
 		newBoxKey(t).GetPublicKey(),
 	}
 	plaintext := make([]byte, 1024*10)
-	if _, err := rand.Read(plaintext); err != nil {
-		t.Fatal(err)
-	}
+	_, err := rand.Read(plaintext)
+	require.NoError(t, err)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
 	require.NoError(t, err)
 	_, plaintext2, err := Open(SingleVersionValidator(version), ciphertext, kr)
 	require.NoError(t, err)
-	if !bytes.Equal(plaintext, plaintext2) {
-		t.Fatal("decryption mismatch")
-	}
+	require.Equal(t, plaintext, plaintext2)
 }
 
 func testRepeatedKey(t *testing.T, version Version) {

--- a/signcrypt_open_test.go
+++ b/signcrypt_open_test.go
@@ -29,7 +29,7 @@ func TestDecryptErrorAtEOF(t *testing.T) {
 	require.NoError(t, err)
 
 	msg, err := ioutil.ReadAll(stream)
-	require.Equal(t, errAtEOF, err)
+	requireErrSuffix(t, err, errAtEOF.Error())
 
 	// Since the bytes are still authenticated, the decrypted
 	// message should still compare equal to the original input.

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireErrSuffix(t *testing.T, err error, suffix string) {
+	t.Helper()
+	require.True(t, strings.HasSuffix(err.Error(), suffix), "err=%v, suffix=%s", err, suffix)
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -69,19 +69,13 @@ func testVerifyConcurrent(t *testing.T, version Version) {
 		go func() {
 			defer wg.Done()
 			skey, msg, err := Verify(SingleVersionValidator(version), smsg, kr)
-			if err != nil {
-				t.Logf("input:      %x", in)
-				t.Logf("signed msg: %x", smsg)
-				t.Error(err)
+			if !assert.NoError(t, err, "input:      %x\nsigned msg: %x", in, smsg) {
 				// Don't fall through, as the tests below will panic.
 				return
 			}
-			if !PublicKeyEqual(skey, key.GetPublicKey()) {
-				t.Errorf("sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
-			}
-			if !bytes.Equal(msg, in) {
-				t.Errorf("verified msg '%x', expected '%x'", msg, in)
-			}
+			assert.True(t, PublicKeyEqual(skey, key.GetPublicKey()),
+				"sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
+			assert.Equal(t, in, msg)
 		}()
 	}
 	wg.Wait()
@@ -128,9 +122,7 @@ func testVerifyErrorAtEOF(t *testing.T, version Version) {
 
 	// Since the bytes are still verified, the verified message
 	// should still compare equal to the original input.
-	if !bytes.Equal(msg, in) {
-		t.Errorf("verified msg '%x', expected '%x'", msg, in)
-	}
+	assert.Equal(t, in, msg)
 }
 
 func TestVerify(t *testing.T) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -160,9 +160,7 @@ func testVerifyErrorAtEOF(t *testing.T, version Version) {
 	}
 
 	msg, err := ioutil.ReadAll(stream)
-	if err != errAtEOF {
-		t.Fatalf("err=%v != errAtEOF=%v", err, errAtEOF)
-	}
+	requireErrSuffix(t, err, errAtEOF.Error())
 
 	// Since the bytes are still verified, the verified message
 	// should still compare equal to the original input.

--- a/verify_test.go
+++ b/verify_test.go
@@ -22,9 +22,7 @@ func TestVerifyVersionValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	_, _, err = Verify(SingleVersionValidator(Version2()), smg, kr)
-	if err == nil {
-		t.Fatal("Unexpected nil error")
-	}
+	require.NotNil(t, err)
 }
 
 func testVerify(t *testing.T, version Version) {
@@ -106,12 +104,7 @@ func testVerifyEmptyKeyring(t *testing.T, version Version) {
 	require.NoError(t, err)
 
 	_, _, err = Verify(SingleVersionValidator(version), smsg, emptySigKeyring{})
-	if err == nil {
-		t.Fatal("Verify worked with empty keyring")
-	}
-	if err != ErrNoSenderKey {
-		t.Errorf("error: %v, expected ErrNoSenderKey", err)
-	}
+	require.Equal(t, ErrNoSenderKey, err)
 }
 
 func testVerifyDetachedEmptyKeyring(t *testing.T, version Version) {
@@ -121,12 +114,7 @@ func testVerifyDetachedEmptyKeyring(t *testing.T, version Version) {
 	require.NoError(t, err)
 
 	_, err = VerifyDetached(SingleVersionValidator(version), msg, sig, emptySigKeyring{})
-	if err == nil {
-		t.Fatal("VerifyDetached worked with empty keyring")
-	}
-	if err != ErrNoSenderKey {
-		t.Errorf("error: %v, expected ErrNoSenderKey", err)
-	}
+	require.Equal(t, ErrNoSenderKey, err)
 }
 
 func testVerifyErrorAtEOF(t *testing.T, version Version) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,17 +32,10 @@ func testVerify(t *testing.T, version Version) {
 	smsg, err := Sign(version, in, key)
 	require.NoError(t, err)
 	skey, msg, err := Verify(SingleVersionValidator(version), smsg, kr)
-	if err != nil {
-		t.Logf("input:      %x", in)
-		t.Logf("signed msg: %x", smsg)
-		t.Fatal(err)
-	}
-	if !PublicKeyEqual(skey, key.GetPublicKey()) {
-		t.Errorf("sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
-	}
-	if !bytes.Equal(msg, in) {
-		t.Errorf("verified msg '%x', expected '%x'", msg, in)
-	}
+	require.NoError(t, err, "input:      %x\nsigned msg: %x", in, smsg)
+	assert.True(t, PublicKeyEqual(skey, key.GetPublicKey()),
+		"sender key %x, expected %x", skey.ToKID(), key.GetPublicKey().ToKID())
+	assert.Equal(t, in, msg)
 }
 
 func testVerifyNewMinorVersion(t *testing.T, version Version) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -19,9 +19,7 @@ func TestVerifyVersionValidator(t *testing.T) {
 	in := []byte{0x01}
 	key := newSigPrivKey(t)
 	smg, err := Sign(Version1(), in, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = Verify(SingleVersionValidator(Version2()), smg, kr)
 	if err == nil {
@@ -33,9 +31,7 @@ func testVerify(t *testing.T, version Version) {
 	in := randomMsg(t, 128)
 	key := newSigPrivKey(t)
 	smsg, err := Sign(version, in, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	skey, msg, err := Verify(SingleVersionValidator(version), smsg, kr)
 	if err != nil {
 		t.Logf("input:      %x", in)
@@ -63,23 +59,17 @@ func testVerifyNewMinorVersion(t *testing.T, version Version) {
 	}
 	key := newSigPrivKey(t)
 	smg, err := testTweakSign(version, in, key, tso)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = Verify(SingleVersionValidator(newVersion), smg, kr)
-	if err != nil {
-		t.Fatalf("Unepected error %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func testVerifyConcurrent(t *testing.T, version Version) {
 	in := randomMsg(t, 128)
 	key := newSigPrivKey(t)
 	smsg, err := Sign(version, in, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
@@ -113,9 +103,7 @@ func testVerifyEmptyKeyring(t *testing.T, version Version) {
 	in := randomMsg(t, 128)
 	key := newSigPrivKey(t)
 	smsg, err := Sign(version, in, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, _, err = Verify(SingleVersionValidator(version), smsg, emptySigKeyring{})
 	if err == nil {
@@ -130,9 +118,7 @@ func testVerifyDetachedEmptyKeyring(t *testing.T, version Version) {
 	key := newSigPrivKey(t)
 	msg := randomMsg(t, 128)
 	sig, err := SignDetached(version, msg, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = VerifyDetached(SingleVersionValidator(version), msg, sig, emptySigKeyring{})
 	if err == nil {
@@ -147,17 +133,13 @@ func testVerifyErrorAtEOF(t *testing.T, version Version) {
 	in := randomMsg(t, 128)
 	key := newSigPrivKey(t)
 	smsg, err := Sign(version, in, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var reader io.Reader = bytes.NewReader(smsg)
 	errAtEOF := errors.New("err at EOF")
 	reader = errAtEOFReader{reader, errAtEOF}
 	_, stream, err := NewVerifyStream(SingleVersionValidator(version), reader, kr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	msg, err := ioutil.ReadAll(stream)
 	requireErrSuffix(t, err, errAtEOF.Error())


### PR DESCRIPTION
It prepends some position info, which messes up our tests.

Convert all files touched to using require/assert.