### PR TITLE
Implement a better shuffle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ go:
 before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
+  - go get golang.org/x/lint/golint
   - go get github.com/axw/gocov/gocov
   - go get github.com/modocache/gover
 script:
+  - go vet ./...
+  - golint ./...
   - go test -coverprofile=basic.coverprofile ./basic
   - go test -coverprofile=basex.coverprofile ./encoding/basex
   - go test -coverprofile=main.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - go test -coverprofile=basic.coverprofile ./basic
   - go test -coverprofile=basex.coverprofile ./encoding/basex
   - go test -coverprofile=main.coverprofile
+  - env GOARCH=386 go test ./...
   - $HOME/gopath/bin/gover
   - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci
 notifications:

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -14,7 +14,7 @@ import (
 
 func encryptArmor62RandomData(t *testing.T, version Version, sz int) ([]byte, string) {
 	msg := randomMsg(t, sz)
-	err := cryptorandRead(msg)
+	err := csprngRead(msg)
 	require.NoError(t, err)
 	sndr := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
@@ -35,7 +35,7 @@ func testEncryptArmor62(t *testing.T, version Version) {
 func testDearmor62DecryptSlowReader(t *testing.T, version Version) {
 	sz := 1024*16 + 3
 	msg := randomMsg(t, sz)
-	err := cryptorandRead(msg)
+	err := csprngRead(msg)
 	require.NoError(t, err)
 	sndr := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -4,7 +4,6 @@
 package saltpack
 
 import (
-	"crypto/rand"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -15,7 +14,7 @@ import (
 
 func encryptArmor62RandomData(t *testing.T, version Version, sz int) ([]byte, string) {
 	msg := randomMsg(t, sz)
-	_, err := rand.Read(msg)
+	err := cryptorandRead(msg)
 	require.NoError(t, err)
 	sndr := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
@@ -36,7 +35,7 @@ func testEncryptArmor62(t *testing.T, version Version) {
 func testDearmor62DecryptSlowReader(t *testing.T, version Version) {
 	sz := 1024*16 + 3
 	msg := randomMsg(t, sz)
-	_, err := rand.Read(msg)
+	err := cryptorandRead(msg)
 	require.NoError(t, err)
 	sndr := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}

--- a/common.go
+++ b/common.go
@@ -45,6 +45,66 @@ func cryptorandRead(b []byte) error {
 	return nil
 }
 
+func cryptorandUint32() (uint32, error) {
+	var buf [4]byte
+	err := cryptorandRead(buf[:])
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint32(buf[:]), nil
+}
+
+// uint32n returns, as an int32, a non-negative pseudo-random number in [0,n).
+// n must be > 0, but int31n does not check this; the caller must ensure it.
+// int31n exists because Int31n is inefficient, but Go 1 compatibility
+// requires that the stream of values produced by math/rand remain unchanged.
+// int31n can thus only be used internally, by newly introduced APIs.
+//
+// For implementation details, see:
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
+// https://lemire.me/blog/2016/06/30/fast-random-shuffling
+func uint32n(n uint32) (uint32, error) {
+	v, err := cryptorandUint32()
+	if err != nil {
+		return 0, err
+	}
+	prod := uint64(v) * uint64(n)
+	low := uint32(prod)
+	if low < uint32(n) {
+		thresh := uint32(-n) % uint32(n)
+		for low < thresh {
+			v, err = cryptorandUint32()
+			if err != nil {
+				return 0, err
+			}
+			prod = uint64(v) * uint64(n)
+			low = uint32(prod)
+		}
+	}
+	return uint32(prod >> 32), err
+}
+
+// shuffle pseudo-randomizes the order of elements.
+// n is the number of elements. Shuffle panics if n < 0.
+// swap swaps the elements with indexes i and j.
+//
+// shuffle is adapted from math/rand.Shuffle from go 1.10.
+func shuffle(n int, swap func(i, j int)) error {
+	if n < 0 || n > ((1<<31)-1) {
+		panic("invalid argument to Shuffle")
+	}
+
+	for i := n - 1; i > 0; i-- {
+		j, err := uint32n(uint32(i + 1))
+		if err != nil {
+			return err
+		}
+		swap(i, int(j))
+	}
+	return nil
+}
+
 type cryptoSource struct {
 	lastErr error
 }

--- a/common.go
+++ b/common.go
@@ -6,7 +6,6 @@ package saltpack
 import (
 	"bytes"
 	"crypto/hmac"
-	cryptorand "crypto/rand"
 	"crypto/sha512"
 	"encoding/binary"
 	"errors"
@@ -30,76 +29,6 @@ func codecHandle() *codec.MsgpackHandle {
 	var mh codec.MsgpackHandle
 	mh.WriteExt = true
 	return &mh
-}
-
-// cryptorandRead is a thin wrapper around crypto/rand.Read that also
-// (paranoidly) checks the length.
-func cryptorandRead(b []byte) error {
-	n, err := cryptorand.Read(b)
-	if err != nil {
-		return err
-	}
-	if n != len(b) {
-		return ErrInsufficientRandomness
-	}
-	return nil
-}
-
-func cryptorandUint32() (uint32, error) {
-	var buf [4]byte
-	err := cryptorandRead(buf[:])
-	if err != nil {
-		return 0, err
-	}
-
-	return binary.BigEndian.Uint32(buf[:]), nil
-}
-
-// uint32n returns, as a uint32, a non-negative pseudo-random number in [0,n).
-// It is adapted from math/rand.int31n.
-//
-// For implementation details, see:
-// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
-// https://lemire.me/blog/2016/06/30/fast-random-shuffling
-func uint32n(n uint32) (uint32, error) {
-	v, err := cryptorandUint32()
-	if err != nil {
-		return 0, err
-	}
-	prod := uint64(v) * uint64(n)
-	low := uint32(prod)
-	if low < n {
-		thresh := -n % n
-		for low < thresh {
-			v, err = cryptorandUint32()
-			if err != nil {
-				return 0, err
-			}
-			prod = uint64(v) * uint64(n)
-			low = uint32(prod)
-		}
-	}
-	return uint32(prod >> 32), err
-}
-
-// shuffle pseudo-randomizes the order of elements.
-// n is the number of elements. Shuffle panics if n < 0.
-// swap swaps the elements with indexes i and j.
-//
-// shuffle is adapted from math/rand.Shuffle from go 1.10.
-func shuffle(n int, swap func(i, j int)) error {
-	if n < 0 || n > ((1<<31)-1) {
-		panic("invalid argument to Shuffle")
-	}
-
-	for i := n - 1; i > 0; i-- {
-		j, err := uint32n(uint32(i + 1))
-		if err != nil {
-			return err
-		}
-		swap(i, int(j))
-	}
-	return nil
 }
 
 type cryptoSource struct {

--- a/common.go
+++ b/common.go
@@ -55,11 +55,8 @@ func cryptorandUint32() (uint32, error) {
 	return binary.BigEndian.Uint32(buf[:]), nil
 }
 
-// uint32n returns, as an int32, a non-negative pseudo-random number in [0,n).
-// n must be > 0, but int31n does not check this; the caller must ensure it.
-// int31n exists because Int31n is inefficient, but Go 1 compatibility
-// requires that the stream of values produced by math/rand remain unchanged.
-// int31n can thus only be used internally, by newly introduced APIs.
+// uint32n returns, as a uint32, a non-negative pseudo-random number in [0,n).
+// It is adapted from math/rand.int31n.
 //
 // For implementation details, see:
 // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
@@ -71,8 +68,8 @@ func uint32n(n uint32) (uint32, error) {
 	}
 	prod := uint64(v) * uint64(n)
 	low := uint32(prod)
-	if low < uint32(n) {
-		thresh := uint32(-n) % uint32(n)
+	if low < n {
+		thresh := -n % n
 		for low < thresh {
 			v, err = cryptorandUint32()
 			if err != nil {

--- a/common.go
+++ b/common.go
@@ -8,9 +8,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha512"
 	"encoding/binary"
-	"errors"
 	"fmt"
-	mathrand "math/rand"
 
 	"github.com/keybase/go-codec/codec"
 	"golang.org/x/crypto/poly1305"
@@ -29,49 +27,6 @@ func codecHandle() *codec.MsgpackHandle {
 	var mh codec.MsgpackHandle
 	mh.WriteExt = true
 	return &mh
-}
-
-type cryptoSource struct {
-	lastErr error
-}
-
-var _ mathrand.Source = (*cryptoSource)(nil)
-
-// No need to implement Source64, since mathrand.Rand.Perm() doesn't use it.
-
-func (s *cryptoSource) Int63() int64 {
-	if s.lastErr != nil {
-		panic("lastErr != nil")
-	}
-
-	var buf [8]byte
-	err := csprngRead(buf[:])
-	if err != nil {
-		s.lastErr = err
-		return 0
-	}
-
-	return int64(binary.BigEndian.Uint64(buf[:]) >> 1)
-}
-
-func (s cryptoSource) Seed(seed int64) {
-	if s.lastErr != nil {
-		panic("lastErr != nil")
-	}
-
-	s.lastErr = errors.New("cryptoSource.Seed() called unexpectedly")
-}
-
-// TODO: Use go 1.10's random.Shuffle instead, which removes a source
-// of bias.
-func randomPerm(n int) ([]int, error) {
-	var source cryptoSource
-	rnd := mathrand.New(&source)
-	perm := rnd.Perm(n)
-	if source.lastErr != nil {
-		return nil, source.lastErr
-	}
-	return perm, nil
 }
 
 func (e encryptionBlockNumber) check() error {

--- a/common.go
+++ b/common.go
@@ -45,7 +45,7 @@ func (s *cryptoSource) Int63() int64 {
 	}
 
 	var buf [8]byte
-	err := cryptorandRead(buf[:])
+	err := csprngRead(buf[:])
 	if err != nil {
 		s.lastErr = err
 		return 0

--- a/encrypt.go
+++ b/encrypt.go
@@ -152,7 +152,8 @@ func checkKnownVersion(version Version) error {
 // receivers. Check that receivers aren't sent to twice; check that
 // there's at least one receiver and not too many receivers.
 func checkEncryptReceivers(receivers []BoxPublicKey) error {
-	if len(receivers) <= 0 || uint32(len(receivers)) > maxReceiverCount {
+	receiverCount := int64(len(receivers))
+	if receiverCount <= 0 || receiverCount > maxReceiverCount {
 		return ErrBadReceivers
 	}
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -151,7 +151,7 @@ func checkKnownVersion(version Version) error {
 // receivers. Check that receivers aren't sent to twice; check that
 // there's at least one receiver and not too many receivers.
 func checkEncryptReceivers(receivers []BoxPublicKey) error {
-	if len(receivers) <= 0 || len(receivers) > maxReceiverCount {
+	if len(receivers) <= 0 || uint32(len(receivers)) > maxReceiverCount {
 		return ErrBadReceivers
 	}
 

--- a/encrypt.go
+++ b/encrypt.go
@@ -5,6 +5,7 @@ package saltpack
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"crypto/sha512"
 	"fmt"
 	"io"
@@ -172,13 +173,13 @@ func checkEncryptReceivers(receivers []BoxPublicKey) error {
 }
 
 func shuffleEncryptReceivers(receivers []BoxPublicKey) ([]BoxPublicKey, error) {
-	order, err := randomPerm(len(receivers))
+	shuffled := make([]BoxPublicKey, len(receivers))
+	copy(shuffled, receivers)
+	err := csprngShuffle(cryptorand.Reader, len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
 	if err != nil {
 		return nil, err
-	}
-	shuffled := make([]BoxPublicKey, len(receivers))
-	for i := 0; i < len(receivers); i++ {
-		shuffled[i] = receivers[order[i]]
 	}
 	return shuffled, nil
 }

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -220,7 +220,7 @@ func newBoxKeyBlacklistPublic(t *testing.T) BoxSecretKey {
 
 func randomMsg(t *testing.T, sz int) []byte {
 	out := make([]byte, sz)
-	_, err := rand.Read(out)
+	err := cryptorandRead(out)
 	require.NoError(t, err)
 	return out
 }
@@ -380,21 +380,21 @@ func testSmallEncryptionOneReceiver(t *testing.T, version Version) {
 
 func testMediumEncryptionOneReceiver(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	_, err := rand.Read(buf)
+	err := cryptorandRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, nil)
 }
 
 func testBiggishEncryptionOneReceiver(t *testing.T, version Version) {
 	buf := make([]byte, 1024*100)
-	_, err := rand.Read(buf)
+	err := cryptorandRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, nil)
 }
 
 func testRealEncryptor(t *testing.T, version Version, sz int) {
 	msg := make([]byte, sz)
-	_, err := rand.Read(msg)
+	err := cryptorandRead(msg)
 	require.NoError(t, err)
 	sndr := newBoxKey(t)
 	var ciphertext bytes.Buffer
@@ -426,7 +426,7 @@ func testRealEncryptorBig(t *testing.T, version Version) {
 
 func testRoundTripMedium6Receivers(t *testing.T, version Version) {
 	msg := make([]byte, 1024*3)
-	_, err := rand.Read(msg)
+	err := cryptorandRead(msg)
 	require.NoError(t, err)
 	receivers := []BoxPublicKey{
 		newBoxKeyNoInsert(t).GetPublicKey(),
@@ -441,7 +441,7 @@ func testRoundTripMedium6Receivers(t *testing.T, version Version) {
 
 func testRoundTripSmall6Receivers(t *testing.T, version Version) {
 	msg := []byte("hoppy halloween")
-	_, err := rand.Read(msg)
+	err := cryptorandRead(msg)
 	require.NoError(t, err)
 	receivers := []BoxPublicKey{
 		newBoxKeyNoInsert(t).GetPublicKey(),
@@ -499,21 +499,21 @@ func testTruncation(t *testing.T, version Version) {
 
 func testMediumEncryptionOneReceiverSmallReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	_, err := rand.Read(buf)
+	err := cryptorandRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 1})
 }
 
 func testMediumEncryptionOneReceiverSmallishReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	_, err := rand.Read(buf)
+	err := cryptorandRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 7})
 }
 
 func testMediumEncryptionOneReceiverMediumReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	_, err := rand.Read(buf)
+	err := cryptorandRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 79})
 }
@@ -522,7 +522,7 @@ func testSealAndOpen(t *testing.T, version Version, sz int) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	plaintext := make([]byte, sz)
-	_, err := rand.Read(plaintext)
+	err := cryptorandRead(plaintext)
 	require.NoError(t, err)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
 	require.NoError(t, err)
@@ -546,7 +546,7 @@ func testSealAndOpenTwoReceivers(t *testing.T, version Version) {
 		newBoxKey(t).GetPublicKey(),
 	}
 	plaintext := make([]byte, 1024*10)
-	_, err := rand.Read(plaintext)
+	err := cryptorandRead(plaintext)
 	require.NoError(t, err)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
 	require.NoError(t, err)

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1494,7 +1494,13 @@ func newRandomEncryptArmor62SealInput(
 	if err != nil {
 		return encryptArmor62SealInput{}, err
 	}
-	permutation, err := randomPerm(receiverCount)
+	permutation := make([]int, receiverCount)
+	for i := 0; i < receiverCount; i++ {
+		permutation[i] = i
+	}
+	err = csprngShuffle(rand.Reader, receiverCount, func(i, j int) {
+		permutation[i], permutation[j] = permutation[j], permutation[i]
+	})
 	if err != nil {
 		return encryptArmor62SealInput{}, err
 	}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -220,7 +220,7 @@ func newBoxKeyBlacklistPublic(t *testing.T) BoxSecretKey {
 
 func randomMsg(t *testing.T, sz int) []byte {
 	out := make([]byte, sz)
-	err := cryptorandRead(out)
+	err := csprngRead(out)
 	require.NoError(t, err)
 	return out
 }
@@ -380,21 +380,21 @@ func testSmallEncryptionOneReceiver(t *testing.T, version Version) {
 
 func testMediumEncryptionOneReceiver(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	err := cryptorandRead(buf)
+	err := csprngRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, nil)
 }
 
 func testBiggishEncryptionOneReceiver(t *testing.T, version Version) {
 	buf := make([]byte, 1024*100)
-	err := cryptorandRead(buf)
+	err := csprngRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, nil)
 }
 
 func testRealEncryptor(t *testing.T, version Version, sz int) {
 	msg := make([]byte, sz)
-	err := cryptorandRead(msg)
+	err := csprngRead(msg)
 	require.NoError(t, err)
 	sndr := newBoxKey(t)
 	var ciphertext bytes.Buffer
@@ -426,7 +426,7 @@ func testRealEncryptorBig(t *testing.T, version Version) {
 
 func testRoundTripMedium6Receivers(t *testing.T, version Version) {
 	msg := make([]byte, 1024*3)
-	err := cryptorandRead(msg)
+	err := csprngRead(msg)
 	require.NoError(t, err)
 	receivers := []BoxPublicKey{
 		newBoxKeyNoInsert(t).GetPublicKey(),
@@ -441,7 +441,7 @@ func testRoundTripMedium6Receivers(t *testing.T, version Version) {
 
 func testRoundTripSmall6Receivers(t *testing.T, version Version) {
 	msg := []byte("hoppy halloween")
-	err := cryptorandRead(msg)
+	err := csprngRead(msg)
 	require.NoError(t, err)
 	receivers := []BoxPublicKey{
 		newBoxKeyNoInsert(t).GetPublicKey(),
@@ -499,21 +499,21 @@ func testTruncation(t *testing.T, version Version) {
 
 func testMediumEncryptionOneReceiverSmallReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	err := cryptorandRead(buf)
+	err := csprngRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 1})
 }
 
 func testMediumEncryptionOneReceiverSmallishReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	err := cryptorandRead(buf)
+	err := csprngRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 7})
 }
 
 func testMediumEncryptionOneReceiverMediumReads(t *testing.T, version Version) {
 	buf := make([]byte, 1024*10)
-	err := cryptorandRead(buf)
+	err := csprngRead(buf)
 	require.NoError(t, err)
 	testRoundTrip(t, version, buf, nil, &options{readSize: 79})
 }
@@ -522,7 +522,7 @@ func testSealAndOpen(t *testing.T, version Version, sz int) {
 	sender := newBoxKey(t)
 	receivers := []BoxPublicKey{newBoxKey(t).GetPublicKey()}
 	plaintext := make([]byte, sz)
-	err := cryptorandRead(plaintext)
+	err := csprngRead(plaintext)
 	require.NoError(t, err)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
 	require.NoError(t, err)
@@ -546,7 +546,7 @@ func testSealAndOpenTwoReceivers(t *testing.T, version Version) {
 		newBoxKey(t).GetPublicKey(),
 	}
 	plaintext := make([]byte, 1024*10)
-	err := cryptorandRead(plaintext)
+	err := csprngRead(plaintext)
 	require.NoError(t, err)
 	ciphertext, err := Seal(version, plaintext, sender, receivers)
 	require.NoError(t, err)

--- a/key.go
+++ b/key.go
@@ -5,7 +5,6 @@ package saltpack
 
 import (
 	"crypto/hmac"
-	cryptorand "crypto/rand"
 )
 
 // RawBoxKey is the raw byte-representation of what a box key should
@@ -27,12 +26,9 @@ type SymmetricKey [32]byte
 
 func newRandomSymmetricKey() (*SymmetricKey, error) {
 	var s SymmetricKey
-	n, err := cryptorand.Read(s[:])
+	err := cryptorandRead(s[:])
 	if err != nil {
 		return nil, err
-	}
-	if n != len(s) {
-		return nil, ErrInsufficientRandomness
 	}
 	return &s, nil
 }

--- a/key.go
+++ b/key.go
@@ -26,7 +26,7 @@ type SymmetricKey [32]byte
 
 func newRandomSymmetricKey() (*SymmetricKey, error) {
 	var s SymmetricKey
-	err := cryptorandRead(s[:])
+	err := csprngRead(s[:])
 	if err != nil {
 		return nil, err
 	}

--- a/nonce.go
+++ b/nonce.go
@@ -88,7 +88,7 @@ type sigNonce [16]byte
 // newSigNonce creates a sigNonce with random bytes.
 func newSigNonce() (sigNonce, error) {
 	var n sigNonce
-	if err := cryptorandRead(n[:]); err != nil {
+	if err := csprngRead(n[:]); err != nil {
 		return sigNonce{}, err
 	}
 	return n, nil

--- a/nonce.go
+++ b/nonce.go
@@ -1,7 +1,6 @@
 package saltpack
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 )
 
@@ -89,7 +88,7 @@ type sigNonce [16]byte
 // newSigNonce creates a sigNonce with random bytes.
 func newSigNonce() (sigNonce, error) {
 	var n sigNonce
-	if _, err := rand.Read(n[:]); err != nil {
+	if err := cryptorandRead(n[:]); err != nil {
 		return sigNonce{}, err
 	}
 	return n, nil

--- a/rand.go
+++ b/rand.go
@@ -65,14 +65,19 @@ func uint32n(csprng io.Reader, n uint32) (uint32, error) {
 	return uint32(prod >> 32), err
 }
 
-// shuffle pseudo-randomizes the order of elements.  n is the number
-// of elements. Shuffle panics if n < 0.  swap swaps the elements with
-// indexes i and j.
+// csprngShuffle randomizes the order of elements given a CSPRNG. n is
+// the number of elements, which must be >= 0 and < 2³¹. swap swaps
+// the elements with indexes i and j.
 //
-// shuffle is adapted from math/rand.Shuffle from go 1.10.
-func shuffle(csprng io.Reader, n int, swap func(i, j int)) error {
-	if n < 0 || n > ((1<<31)-1) {
-		panic("invalid argument to Shuffle")
+// This function implements
+// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle , and is
+// adapted from math/rand.Shuffle from go 1.10.
+func csprngShuffle(csprng io.Reader, n int, swap func(i, j int)) error {
+	if n < 0 {
+		panic("csprngShuffle: n < 0")
+	}
+	if n > ((1 << 31) - 1) {
+		panic("csprngShuffle: n >= 2³¹")
 	}
 
 	for i := n - 1; i > 0; i-- {

--- a/rand.go
+++ b/rand.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import "encoding/binary"
+import cryptorand "crypto/rand"
+
+// cryptorandRead is a thin wrapper around crypto/rand.Read that also
+// (paranoidly) checks the length.
+func cryptorandRead(b []byte) error {
+	n, err := cryptorand.Read(b)
+	if err != nil {
+		return err
+	}
+	if n != len(b) {
+		return ErrInsufficientRandomness
+	}
+	return nil
+}
+
+func cryptorandUint32() (uint32, error) {
+	var buf [4]byte
+	err := cryptorandRead(buf[:])
+	if err != nil {
+		return 0, err
+	}
+
+	return binary.BigEndian.Uint32(buf[:]), nil
+}
+
+// uint32n returns, as a uint32, a non-negative pseudo-random number
+// in [0,n).  It is adapted from math/rand.int31n from go 1.10.
+//
+// For implementation details, see:
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
+// https://lemire.me/blog/2016/06/30/fast-random-shuffling
+func uint32n(n uint32) (uint32, error) {
+	v, err := cryptorandUint32()
+	if err != nil {
+		return 0, err
+	}
+	prod := uint64(v) * uint64(n)
+	low := uint32(prod)
+	if low < n {
+		thresh := -n % n
+		for low < thresh {
+			v, err = cryptorandUint32()
+			if err != nil {
+				return 0, err
+			}
+			prod = uint64(v) * uint64(n)
+			low = uint32(prod)
+		}
+	}
+	return uint32(prod >> 32), err
+}
+
+// shuffle pseudo-randomizes the order of elements.  n is the number
+// of elements. Shuffle panics if n < 0.  swap swaps the elements with
+// indexes i and j.
+//
+// shuffle is adapted from math/rand.Shuffle from go 1.10.
+func shuffle(n int, swap func(i, j int)) error {
+	if n < 0 || n > ((1<<31)-1) {
+		panic("invalid argument to Shuffle")
+	}
+
+	for i := n - 1; i > 0; i-- {
+		j, err := uint32n(uint32(i + 1))
+		if err != nil {
+			return err
+		}
+		swap(i, int(j))
+	}
+	return nil
+}

--- a/rand.go
+++ b/rand.go
@@ -62,7 +62,7 @@ func uint32n(csprng io.Reader, n uint32) (uint32, error) {
 			low = uint32(prod)
 		}
 	}
-	return uint32(prod >> 32), err
+	return uint32(prod >> 32), nil
 }
 
 // csprngShuffle randomizes the order of elements given a CSPRNG. n is

--- a/rand.go
+++ b/rand.go
@@ -9,9 +9,9 @@ import (
 	"io"
 )
 
-// cryptorandReadFull is a thin wrapper around io.ReadFull on a given
+// csprngReadFull is a thin wrapper around io.ReadFull on a given
 // CSPRNG that also (paranoidly) checks the length.
-func cryptorandReadFull(csprng io.Reader, b []byte) error {
+func csprngReadFull(csprng io.Reader, b []byte) error {
 	n, err := io.ReadFull(csprng, b)
 	if err != nil {
 		return err
@@ -22,15 +22,17 @@ func cryptorandReadFull(csprng io.Reader, b []byte) error {
 	return nil
 }
 
-// cryptorandRead is like crypto/rand.Read, except it uses
-// cryptorandReadFull instead of io.ReadFull.
-func cryptorandRead(b []byte) error {
-	return cryptorandReadFull(cryptorand.Reader, b)
+// csprngRead is like crypto/rand.Read, except it uses csprngReadFull
+// instead of io.ReadFull.
+func csprngRead(b []byte) error {
+	return csprngReadFull(cryptorand.Reader, b)
 }
 
-func cryptorandUint32(csprng io.Reader) (uint32, error) {
+// csprngUint32, given a CSPRNG, returns a uniformly distributed
+// random number in [0, 2³²).
+func csprngUint32(csprng io.Reader) (uint32, error) {
 	var buf [4]byte
-	err := cryptorandReadFull(csprng, buf[:])
+	err := csprngReadFull(csprng, buf[:])
 	if err != nil {
 		return 0, err
 	}
@@ -46,7 +48,7 @@ func cryptorandUint32(csprng io.Reader) (uint32, error) {
 // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
 // https://lemire.me/blog/2016/06/30/fast-random-shuffling
 func csprngUint32n(csprng io.Reader, n uint32) (uint32, error) {
-	v, err := cryptorandUint32(csprng)
+	v, err := csprngUint32(csprng)
 	if err != nil {
 		return 0, err
 	}
@@ -55,7 +57,7 @@ func csprngUint32n(csprng io.Reader, n uint32) (uint32, error) {
 	if low < n {
 		thresh := -n % n
 		for low < thresh {
-			v, err = cryptorandUint32(csprng)
+			v, err = csprngUint32(csprng)
 			if err != nil {
 				return 0, err
 			}

--- a/rand.go
+++ b/rand.go
@@ -38,13 +38,13 @@ func cryptorandUint32(csprng io.Reader) (uint32, error) {
 	return binary.BigEndian.Uint32(buf[:]), nil
 }
 
-// uint32n returns, as a uint32, a non-negative pseudo-random number
-// in [0,n).  It is adapted from math/rand.int31n from go 1.10.
+// csprngUint32n returns, as a uint32, a non-negative pseudo-random
+// number in [0,n).  It is adapted from math/rand.int31n from go 1.10.
 //
 // For implementation details, see:
 // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
 // https://lemire.me/blog/2016/06/30/fast-random-shuffling
-func uint32n(csprng io.Reader, n uint32) (uint32, error) {
+func csprngUint32n(csprng io.Reader, n uint32) (uint32, error) {
 	v, err := cryptorandUint32(csprng)
 	if err != nil {
 		return 0, err
@@ -81,7 +81,7 @@ func csprngShuffle(csprng io.Reader, n int, swap func(i, j int)) error {
 	}
 
 	for i := n - 1; i > 0; i-- {
-		j, err := uint32n(csprng, uint32(i+1))
+		j, err := csprngUint32n(csprng, uint32(i+1))
 		if err != nil {
 			return err
 		}

--- a/rand.go
+++ b/rand.go
@@ -38,8 +38,9 @@ func cryptorandUint32(csprng io.Reader) (uint32, error) {
 	return binary.BigEndian.Uint32(buf[:]), nil
 }
 
-// csprngUint32n returns, as a uint32, a non-negative pseudo-random
-// number in [0,n).  It is adapted from math/rand.int31n from go 1.10.
+// csprngUint32n, given a CSPRNG, returns, as a uint32, a uniformly
+// distributed random number in [0, n). It is adapted from
+// math/rand.int31n from go 1.10.
 //
 // For implementation details, see:
 // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction

--- a/rand.go
+++ b/rand.go
@@ -1,5 +1,37 @@
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 // Copyright 2018 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
+
+// (Following the advice of
+// https://softwareengineering.stackexchange.com/a/264363 re. above
+// copyright notices.)
 
 package saltpack
 

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -38,7 +38,11 @@ func (s testReaderSource) Seed(seed int64) {
 }
 
 func TestShuffle(t *testing.T) {
-	input := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	count := 100000
+	var input []int
+	for i := 0; i < count; i++ {
+		input = append(input, i)
+	}
 
 	expectedOutput := make([]int, len(input))
 	output := make([]int, len(input))

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -138,19 +138,19 @@ func testCSPRNGUint32nUniform(t *testing.T, n uint32) {
 	}
 }
 
-func TestCSPRNGUint32nUniform49(t *testing.T) {
+func TestCSPRNGUint32nUniform(t *testing.T) {
 	// 49 is coprime to 2³².
-	testCSPRNGUint32nUniform(t, 49)
-}
-
-func TestCSPRNGUint32nUniform100(t *testing.T) {
+	t.Run("49", func(t *testing.T) {
+		testCSPRNGUint32nUniform(t, 49)
+	})
 	// 100 shares a factor with 2³².
-	testCSPRNGUint32nUniform(t, 100)
-}
-
-func TestCSPRNGUint32nUniform65536(t *testing.T) {
+	t.Run("100", func(t *testing.T) {
+		testCSPRNGUint32nUniform(t, 100)
+	})
 	// 65536 divides 2³².
-	testCSPRNGUint32nUniform(t, 65536)
+	t.Run("65536", func(t *testing.T) {
+		testCSPRNGUint32nUniform(t, 65536)
+	})
 }
 
 type testReaderSource struct {
@@ -216,18 +216,17 @@ func testCSPRNGShuffle(t *testing.T, size int) {
 	require.Equal(t, 0, r.Len())
 }
 
-func TestCSPRNGShuffle100(t *testing.T) {
-	testCSPRNGShuffle(t, 100)
-}
-
-func TestCSPRNGShuffle1000(t *testing.T) {
-	testCSPRNGShuffle(t, 1000)
-}
-
-func TestCSPRNGShuffle10000(t *testing.T) {
-	testCSPRNGShuffle(t, 10000)
-}
-
-func TestCSPRNGShuffle100000(t *testing.T) {
-	testCSPRNGShuffle(t, 100000)
+func TestCSPRNGShuffle(t *testing.T) {
+	for _, size := range []int{
+		100,
+		16807, // 7⁵
+		65536,
+		100000,
+	} {
+		// Capture range variable.
+		size := size
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			testCSPRNGShuffle(t, size)
+		})
+	}
 }

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -69,8 +69,9 @@ func TestCSPRNGUint32nUniform(t *testing.T) {
 		n, err := csprngUint32n(r, 100)
 		if err != nil {
 			require.Equal(t, io.EOF, err)
+		} else {
+			buckets[n]++
 		}
-		buckets[n]++
 	}
 
 	for i := 0; i < 100; i++ {

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -74,7 +74,7 @@ func TestCSPRNGUint32nUniform(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		assert.Equal(t, (1<<32)/100, buckets[i], "i=%d", i)
+		assert.Equal(t, uint64((1<<32)/100), buckets[i], "i=%d", i)
 	}
 }
 

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -28,6 +28,13 @@ func TestCSPRNGUint32(t *testing.T) {
 	require.Equal(t, uint32(0xdeadbeef), n)
 }
 
+func TestCSPRNGUint32Error(t *testing.T) {
+	var buf [3]byte
+	r := bytes.NewReader(buf[:])
+	_, err := csprngUint32(r)
+	require.Equal(t, io.ErrUnexpectedEOF, err)
+}
+
 func TestCSPRNGUint32nFastPath(t *testing.T) {
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], 0xdeadbeef)

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -20,7 +20,7 @@ type testReaderSource struct {
 var _ mathrand.Source = testReaderSource{}
 
 func (s testReaderSource) Int63() int64 {
-	n, err := cryptorandUint32(cryptorand.Reader)
+	n, err := cryptorandUint32(s.r)
 	require.NoError(s.t, err)
 	return int64(n)
 }

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -67,6 +67,8 @@ func TestCSPRNGUint32nSlowPath(t *testing.T) {
 	require.Equal(t, 0, r.Len())
 }
 
+// A flag controlling whether to run long-running tests that is false
+// by default.
 var long = flag.Bool("long", false, "whether to run long-running tests")
 
 func TestCSPRNGUint32nUniform(t *testing.T) {

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -45,6 +45,9 @@ func (s testReaderSource) Seed(seed int64) {
 	s.t.Fatal("testReaderSource.Seed() called unexpectedly")
 }
 
+// Test that our shuffle matches exactly math/rand.Shuffle for sizes <
+// 2³¹. This is a robust test, since go's backwards compatibility
+// guarantee also applies to the behavior of math/rand.Rand.
 func TestShuffle(t *testing.T) {
 	count := 100000
 	var input []int

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -5,26 +5,28 @@ package saltpack
 
 import (
 	cryptorand "crypto/rand"
+	"io"
 	mathrand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-type testCryptoSource struct {
+type testReaderSource struct {
 	t *testing.T
+	r io.Reader
 }
 
-var _ mathrand.Source = testCryptoSource{}
+var _ mathrand.Source = testReaderSource{}
 
-func (s testCryptoSource) Int63() int64 {
+func (s testReaderSource) Int63() int64 {
 	n, err := cryptorandUint32(cryptorand.Reader)
 	require.NoError(s.t, err)
 	return int64(n)
 }
 
-func (s testCryptoSource) Seed(seed int64) {
-	s.t.Fatal("testCryptoSource.Seed() called unexpectedly")
+func (s testReaderSource) Seed(seed int64) {
+	s.t.Fatal("testReaderSource.Seed() called unexpectedly")
 }
 
 func TestShuffle(t *testing.T) {
@@ -36,7 +38,7 @@ func TestShuffle(t *testing.T) {
 	copy(expectedOutput, input)
 	copy(output, input)
 
-	rnd := mathrand.New(testCryptoSource{t})
+	rnd := mathrand.New(testReaderSource{t, cryptorand.Reader})
 	rnd.Shuffle(len(expectedOutput), func(i, j int) {
 		expectedOutput[i], expectedOutput[j] =
 			expectedOutput[j], expectedOutput[i]

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -76,6 +76,10 @@ func testCSPRNGUint32nUniform(t *testing.T, n uint32) {
 		t.Skip()
 	}
 
+	// Split the 32-bit range into roughly equal ranges for each
+	// worker and have each worker keep a count of how many times
+	// each number is returned.
+
 	workerCount := runtime.NumCPU()
 	workerBuckets := make([][]uint64, workerCount)
 	for i := 0; i < workerCount; i++ {
@@ -119,8 +123,11 @@ func testCSPRNGUint32nUniform(t *testing.T, n uint32) {
 
 	w.Wait()
 
+	// Then add together all the counts. Each number should appear
+	// exactly floor(2³²/n) times.
+
 	buckets := make([]uint64, n)
-	for i := 0; i < 100; i++ {
+	for i := uint32(0); i < n; i++ {
 		for j := 0; j < workerCount; j++ {
 			buckets[i] += workerBuckets[j][i]
 		}

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -139,14 +139,17 @@ func testCSPRNGUint32nUniform(t *testing.T, n uint32) {
 }
 
 func TestCSPRNGUint32nUniform49(t *testing.T) {
+	// 49 is coprime to 2³².
 	testCSPRNGUint32nUniform(t, 49)
 }
 
 func TestCSPRNGUint32nUniform100(t *testing.T) {
+	// 100 shares a factor with 2³².
 	testCSPRNGUint32nUniform(t, 100)
 }
 
 func TestCSPRNGUint32nUniform65536(t *testing.T) {
+	// 65536 divides 2³².
 	testCSPRNGUint32nUniform(t, 65536)
 }
 

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -171,8 +171,7 @@ func (s *testReaderSource) Int63() int64 {
 	// top 32 bits after the sign bit.
 	n := int64(uint32) << 31
 
-	// Assumes that cryptorandUint32 uses big endian. (This way,
-	// we can test cryptorandUint32, too).
+	// Assumes that cryptorandUint32 uses big endian.
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], uint32)
 	s.read = append(s.read, buf[:]...)

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -3,8 +3,49 @@
 
 package saltpack
 
-import "testing"
+import (
+	cryptorand "crypto/rand"
+	mathrand "math/rand"
+	"testing"
 
-func TestCryptoRandUint32(t *testing.T) {
+	"github.com/stretchr/testify/require"
+)
 
+type testCryptoSource struct {
+	t *testing.T
+}
+
+var _ mathrand.Source = testCryptoSource{}
+
+func (s testCryptoSource) Int63() int64 {
+	n, err := cryptorandUint32(cryptorand.Reader)
+	require.NoError(s.t, err)
+	return int64(n)
+}
+
+func (s testCryptoSource) Seed(seed int64) {
+	s.t.Fatal("testCryptoSource.Seed() called unexpectedly")
+}
+
+func TestShuffle(t *testing.T) {
+	input := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	expectedOutput := make([]int, len(input))
+	output := make([]int, len(input))
+
+	copy(expectedOutput, input)
+	copy(output, input)
+
+	rnd := mathrand.New(testCryptoSource{t})
+	rnd.Shuffle(len(expectedOutput), func(i, j int) {
+		expectedOutput[i], expectedOutput[j] =
+			expectedOutput[j], expectedOutput[i]
+	})
+
+	shuffle(cryptorand.Reader, len(output), func(i, j int) {
+		output[i], output[j] =
+			output[j], output[i]
+	})
+
+	require.Equal(t, expectedOutput, output)
 }

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -139,18 +139,17 @@ func testCSPRNGUint32nUniform(t *testing.T, n uint32) {
 }
 
 func TestCSPRNGUint32nUniform(t *testing.T) {
-	// 49 is coprime to 2³².
-	t.Run("49", func(t *testing.T) {
-		testCSPRNGUint32nUniform(t, 49)
-	})
-	// 100 shares a factor with 2³².
-	t.Run("100", func(t *testing.T) {
-		testCSPRNGUint32nUniform(t, 100)
-	})
-	// 65536 divides 2³².
-	t.Run("65536", func(t *testing.T) {
-		testCSPRNGUint32nUniform(t, 65536)
-	})
+	for _, n := range []uint32{
+		49,    // coprime to 2³²
+		100,   // shares factors with 2³²
+		65536, // divides 2³²
+	} {
+		// Capture range variable.
+		n := n
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
+			testCSPRNGUint32nUniform(t, n)
+		})
+	}
 }
 
 type testReaderSource struct {

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -106,6 +106,9 @@ func testCSPRNGUint32nUniform(t *testing.T, n uint32) {
 			r := bytes.NewReader(buf[:])
 			for j := start; j < end; j++ {
 				if j%10000000 == 0 {
+					// Use fmt.Printf instead of
+					// t.Log so that it prints as
+					// the test is running.
 					fmt.Printf("worker %d/%d: %.2f%% done\n", i+1, workerCount, float64(j-start)*100/float64(end-start))
 				}
 

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -1,0 +1,10 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import "testing"
+
+func TestCryptoRandUint32(t *testing.T) {
+
+}

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -183,15 +183,15 @@ func (s testReaderSource) Seed(seed int64) {
 	s.t.Fatal("testReaderSource.Seed() called unexpectedly")
 }
 
-// TestCSPRNGShuffle tests that csprngShuffle exactly matches
-// math/rand.Shuffle for sizes < 2³¹. This is a robust test, since
-// go's backwards compatibility guarantee also applies to the behavior
-// of math/rand.Rand for a given seed.
-func TestCSPRNGShuffle(t *testing.T) {
-	count := 100000
+// testCSPRNGShuffle tests that csprngShuffle exactly matches
+// math/rand.Shuffle for the given size, which must be less than
+// 2³¹. This is a robust test, since go's backwards compatibility
+// guarantee also applies to the behavior of math/rand.Rand for a
+// given seed.
+func testCSPRNGShuffle(t *testing.T, size int) {
 	var input []int
-	for i := 0; i < count; i++ {
-		input = append(input, i)
+	for i := 0; i < size; i++ {
+		input = append(input, size)
 	}
 
 	expectedOutput := make([]int, len(input))
@@ -214,4 +214,20 @@ func TestCSPRNGShuffle(t *testing.T) {
 
 	require.Equal(t, expectedOutput, output)
 	require.Equal(t, 0, r.Len())
+}
+
+func TestCSPRNGShuffle100(t *testing.T) {
+	testCSPRNGShuffle(t, 100)
+}
+
+func TestCSPRNGShuffle1000(t *testing.T) {
+	testCSPRNGShuffle(t, 1000)
+}
+
+func TestCSPRNGShuffle10000(t *testing.T) {
+	testCSPRNGShuffle(t, 10000)
+}
+
+func TestCSPRNGShuffle100000(t *testing.T) {
+	testCSPRNGShuffle(t, 100000)
 }

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -45,9 +45,10 @@ func (s testReaderSource) Seed(seed int64) {
 	s.t.Fatal("testReaderSource.Seed() called unexpectedly")
 }
 
-// Test that our shuffle matches exactly math/rand.Shuffle for sizes <
-// 2³¹. This is a robust test, since go's backwards compatibility
-// guarantee also applies to the behavior of math/rand.Rand.
+// TestShuffle tests that our shuffle matches exactly
+// math/rand.Shuffle for sizes < 2³¹. This is a robust test, since
+// go's backwards compatibility guarantee also applies to the behavior
+// of math/rand.Rand.
 func TestShuffle(t *testing.T) {
 	count := 100000
 	var input []int

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -19,6 +19,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCSPRNGUint32(t *testing.T) {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], 0xdeadbeef)
+	r := bytes.NewReader(buf[:])
+	n, err := csprngUint32(r)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0xdeadbeef), n)
+}
+
 func TestCSPRNGUint32nFastPath(t *testing.T) {
 	var buf [4]byte
 	binary.BigEndian.PutUint32(buf[:], 0xdeadbeef)
@@ -120,7 +129,7 @@ type testReaderSource struct {
 var _ mathrand.Source = (*testReaderSource)(nil)
 
 func (s *testReaderSource) Int63() int64 {
-	uint32, err := cryptorandUint32(s.r)
+	uint32, err := csprngUint32(s.r)
 	require.NoError(s.t, err)
 
 	// math/rand.Shuffle calls r.Uint32(), which returns

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -1,6 +1,8 @@
 // Copyright 2018 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
+// +build go1.10
+
 package saltpack
 
 import (

--- a/rand_1.10_test.go
+++ b/rand_1.10_test.go
@@ -70,7 +70,7 @@ func TestShuffle(t *testing.T) {
 	})
 
 	read := bytes.NewBuffer(sourceExpected.read)
-	shuffle(read, len(output), func(i, j int) {
+	csprngShuffle(read, len(output), func(i, j int) {
 		output[i], output[j] = output[j], output[i]
 	})
 

--- a/sign_test.go
+++ b/sign_test.go
@@ -322,7 +322,7 @@ func testSignAttachedVerifyDetached(t *testing.T, version Version) {
 
 func testSignBadKey(t *testing.T, version Version) {
 	key := newSigPrivKey(t)
-	rand.Read(key.private[:])
+	cryptorandRead(key.private[:])
 	msg := randomMsg(t, 128)
 	smsg, err := Sign(version, msg, key)
 	if err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -322,7 +322,7 @@ func testSignAttachedVerifyDetached(t *testing.T, version Version) {
 
 func testSignBadKey(t *testing.T, version Version) {
 	key := newSigPrivKey(t)
-	cryptorandRead(key.private[:])
+	csprngRead(key.private[:])
 	msg := randomMsg(t, 128)
 	smsg, err := Sign(version, msg, key)
 	if err != nil {

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -195,8 +195,16 @@ func (r ReceiverSymmetricKey) makeReceiverKeys(ephemeralPriv BoxSecretKey, paylo
 // receivers. Check that receivers aren't sent to twice; check that
 // there's at least one receiver and not too many receivers.
 func checkSigncryptReceivers(receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) error {
-	receiverCount := len(receiverBoxKeys) + len(receiverSymmetricKeys)
-	if receiverCount <= 0 || uint32(receiverCount) > maxReceiverCount {
+	// Handle possible (but unlikely) overflow when adding
+	// together the two sizes.
+	if uint32(len(receiverBoxKeys)) > maxReceiverCount {
+		return ErrBadReceivers
+	}
+	if uint32(len(receiverSymmetricKeys)) > maxReceiverCount {
+		return ErrBadReceivers
+	}
+	receiverCount := uint64(len(receiverBoxKeys)) + uint64(len(receiverSymmetricKeys))
+	if receiverCount <= 0 || receiverCount > maxReceiverCount {
 		return ErrBadReceivers
 	}
 

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -198,10 +198,10 @@ func (r ReceiverSymmetricKey) makeReceiverKeys(ephemeralPriv BoxSecretKey, paylo
 func checkSigncryptReceivers(receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) error {
 	// Handle possible (but unlikely) overflow when adding
 	// together the two sizes.
-	if uint32(len(receiverBoxKeys)) > maxReceiverCount {
+	if uint64(len(receiverBoxKeys)) > maxReceiverCount {
 		return ErrBadReceivers
 	}
-	if uint32(len(receiverSymmetricKeys)) > maxReceiverCount {
+	if uint64(len(receiverSymmetricKeys)) > maxReceiverCount {
 		return ErrBadReceivers
 	}
 	receiverCount := uint64(len(receiverBoxKeys)) + uint64(len(receiverSymmetricKeys))

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -193,6 +193,14 @@ func (r ReceiverSymmetricKey) makeReceiverKeys(ephemeralPriv BoxSecretKey, paylo
 }
 
 func checkSigncryptReceiverCount(receiverBoxKeyCount, receiverSymmetricKeyCount int) error {
+	c1 := int64(receiverBoxKeyCount)
+	c2 := int64(receiverSymmetricKeyCount)
+	if c1 < 0 {
+		panic("Bogus recieverBoxKeyCount")
+	}
+	if c2 < 0 {
+		panic("Bogus recieverSymmetricKeyCount")
+	}
 	// Handle possible (but unlikely) overflow when adding
 	// together the two sizes.
 	if uint64(receiverBoxKeyCount) > maxReceiverCount {

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -203,14 +203,14 @@ func checkSigncryptReceiverCount(receiverBoxKeyCount, receiverSymmetricKeyCount 
 	}
 	// Handle possible (but unlikely) overflow when adding
 	// together the two sizes.
-	if uint64(receiverBoxKeyCount) > maxReceiverCount {
+	if c1 > maxReceiverCount {
 		return ErrBadReceivers
 	}
-	if uint64(receiverSymmetricKeyCount) > maxReceiverCount {
+	if c2 > maxReceiverCount {
 		return ErrBadReceivers
 	}
-	receiverCount := uint64(receiverBoxKeyCount) + uint64(receiverSymmetricKeyCount)
-	if receiverCount <= 0 || receiverCount > maxReceiverCount {
+	c := c1 + c2
+	if c <= 0 || c > maxReceiverCount {
 		return ErrBadReceivers
 	}
 

--- a/signcrypt_seal.go
+++ b/signcrypt_seal.go
@@ -196,7 +196,7 @@ func (r ReceiverSymmetricKey) makeReceiverKeys(ephemeralPriv BoxSecretKey, paylo
 // there's at least one receiver and not too many receivers.
 func checkSigncryptReceivers(receiverBoxKeys []BoxPublicKey, receiverSymmetricKeys []ReceiverSymmetricKey) error {
 	receiverCount := len(receiverBoxKeys) + len(receiverSymmetricKeys)
-	if receiverCount <= 0 || receiverCount > maxReceiverCount {
+	if receiverCount <= 0 || uint32(receiverCount) > maxReceiverCount {
 		return ErrBadReceivers
 	}
 

--- a/signcrypt_seal_amd64_test.go
+++ b/signcrypt_seal_amd64_test.go
@@ -1,0 +1,23 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build amd64
+
+package saltpack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckSigncryptReceiverCountAMD64(t *testing.T) {
+	err := checkSigncryptReceiverCount(maxReceiverCount, 1)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(1, maxReceiverCount)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(maxReceiverCount, maxReceiverCount)
+	require.Equal(t, ErrBadReceivers, err)
+}

--- a/signcrypt_seal_i386_test.go
+++ b/signcrypt_seal_i386_test.go
@@ -1,0 +1,25 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build 386
+
+package saltpack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckSigncryptReceiverCount386(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+
+	err := checkSigncryptReceiverCount(maxInt, 1)
+	require.NoError(t, err)
+
+	err = checkSigncryptReceiverCount(1, maxInt)
+	require.NoError(t, err)
+
+	err = checkSigncryptReceiverCount(maxInt, maxInt)
+	require.NoError(t, err)
+}

--- a/signcrypt_seal_test.go
+++ b/signcrypt_seal_test.go
@@ -20,11 +20,12 @@ func TestCheckSigncryptReceiverCount(t *testing.T) {
 	err = checkSigncryptReceiverCount(0, 1)
 	require.NoError(t, err)
 
-	err = checkSigncryptReceiverCount(-1, 0)
-	require.Equal(t, ErrBadReceivers, err)
-
-	err = checkSigncryptReceiverCount(0, -1)
-	require.Equal(t, ErrBadReceivers, err)
+	require.Panics(t, func() {
+		checkSigncryptReceiverCount(-1, 0)
+	})
+	require.Panics(t, func() {
+		checkSigncryptReceiverCount(0, -1)
+	})
 
 	err = checkSigncryptReceiverCount(maxReceiverCount, 1)
 	require.Equal(t, ErrBadReceivers, err)

--- a/signcrypt_seal_test.go
+++ b/signcrypt_seal_test.go
@@ -10,6 +10,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCheckSigncryptReceiverCount(t *testing.T) {
+	err := checkSigncryptReceiverCount(0, 0)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(1, 0)
+	require.NoError(t, err)
+
+	err = checkSigncryptReceiverCount(0, 1)
+	require.NoError(t, err)
+
+	err = checkSigncryptReceiverCount(-1, 0)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(0, -1)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(maxReceiverCount, 1)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(1, maxReceiverCount)
+	require.Equal(t, ErrBadReceivers, err)
+
+	err = checkSigncryptReceiverCount(maxReceiverCount, maxReceiverCount)
+	require.Equal(t, ErrBadReceivers, err)
+}
+
 func getSigncryptionReceiverOrder(receivers []receiverKeysMaker) []int {
 	order := make([]int, len(receivers))
 	for i, r := range receivers {

--- a/signcrypt_seal_test.go
+++ b/signcrypt_seal_test.go
@@ -26,15 +26,6 @@ func TestCheckSigncryptReceiverCount(t *testing.T) {
 	require.Panics(t, func() {
 		checkSigncryptReceiverCount(0, -1)
 	})
-
-	err = checkSigncryptReceiverCount(maxReceiverCount, 1)
-	require.Equal(t, ErrBadReceivers, err)
-
-	err = checkSigncryptReceiverCount(1, maxReceiverCount)
-	require.Equal(t, ErrBadReceivers, err)
-
-	err = checkSigncryptReceiverCount(maxReceiverCount, maxReceiverCount)
-	require.Equal(t, ErrBadReceivers, err)
 }
 
 func getSigncryptionReceiverOrder(receivers []receiverKeysMaker) []int {


### PR DESCRIPTION
Copy the shuffle code from go 1.10's math/rand.Shuffle, which is unbiased. Reasons for copying:

- Don't have to deal with the awkwardness of trying to make the shuffle function
  handle errors from crypto/rand.Reader properly. (Or rather, the awkwardness is
  pushed to the less critical testing code.)
- Works with earlier versions of go.
- Low chance of behavior drift, since rand.Shuffle is covered by compatibility
  guarantee.
- Only adds 50 or so lines of non-test code.

Also make as much as possible use `csprngRead` utility function.

Also handle unlikely overflow in receiver count when signcrypting.

Run go vet, golint, and GOARCH=386 tests in CI.