### PR TITLE
Clarify MessagePack encoding in spec

### DIFF
--- a/msgpack.go
+++ b/msgpack.go
@@ -27,6 +27,10 @@ func encodeToBytes(i interface{}) ([]byte, error) {
 // decodeFromBytes would succeed even if the version numbers or mode
 // aren't encoded as positive fixnums. Ideally, it would reject those
 // as malformed, but there's no easy way to do that.
+//
+// Similarly, we'd ideally reject strings, byte arrays, or arrays that
+// aren't minimally encoded, but there's no easy way to check that
+// either.
 
 func decodeFromBytes(p interface{}, b []byte) error {
 	return codec.NewDecoderBytes(b, codecHandle()).Decode(p)

--- a/msgpack.go
+++ b/msgpack.go
@@ -23,6 +23,11 @@ func encodeToBytes(i interface{}) ([]byte, error) {
 	return encoded, err
 }
 
+// If p has type {Encryption,Signcryption,Signature}Header, then
+// decodeFromBytes would succeed even if the version numbers or mode
+// aren't encoded as positive fixnums. Ideally, it would reject those
+// as malformed, but there's no easy way to do that.
+
 func decodeFromBytes(p interface{}, b []byte) error {
 	return codec.NewDecoderBytes(b, codecHandle()).Decode(p)
 }

--- a/packets_test.go
+++ b/packets_test.go
@@ -23,6 +23,51 @@ func TestHeaderHardcoded(t *testing.T) {
 	require.Equal(t, expectedBytes, bytes)
 }
 
+// Test that strings are encoded with the fewest number of bytes.
+func TestEncodedStringLength(t *testing.T) {
+	s := string(make([]byte, 31))
+	bytes, err := encodeToBytes(s)
+	require.NoError(t, err)
+	require.Equal(t, 31+1, len(bytes))
+
+	s = string(make([]byte, 255))
+	bytes, err = encodeToBytes(s)
+	require.NoError(t, err)
+	require.Equal(t, 255+2, len(bytes))
+
+	s = string(make([]byte, 65535))
+	bytes, err = encodeToBytes(s)
+	require.NoError(t, err)
+	require.Equal(t, 65535+3, len(bytes))
+}
+
+// Test that byte arrays are encoded with the fewest number of bytes.
+func TestEncodedByteArrayLength(t *testing.T) {
+	b := make([]byte, 255)
+	bytes, err := encodeToBytes(b)
+	require.NoError(t, err)
+	require.Equal(t, 255+2, len(bytes))
+
+	b = make([]byte, 65535)
+	bytes, err = encodeToBytes(b)
+	require.NoError(t, err)
+	require.Equal(t, 65535+3, len(bytes))
+}
+
+// Test that generic arrays are encoded with the fewest number of bytes.
+func TestEncodedArrayLength(t *testing.T) {
+	// A [1]bool should encode as two bytes.
+	b := make([][1]bool, 15)
+	bytes, err := encodeToBytes(b)
+	require.NoError(t, err)
+	require.Equal(t, 2*15+1, len(bytes))
+
+	b = make([][1]bool, 65535)
+	bytes, err = encodeToBytes(b)
+	require.NoError(t, err)
+	require.Equal(t, 65535*2+3, len(bytes))
+}
+
 // Test that encryptionBlockV2 encodes and decodes properly.
 func TestEncryptionBlockV2RoundTrip(t *testing.T) {
 	isFinal := false

--- a/packets_test.go
+++ b/packets_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test that ints in headers are encoded as positive fixnums.
+func TestHeaderHardcoded(t *testing.T) {
+	header := EncryptionHeader{
+		Version: Version2(),
+		Type:    MessageTypeDetachedSignature,
+	}
+
+	expectedBytes := []byte{0x96, 0xa0, 0x92, 0x2, 0x0, 0x2, 0xc0, 0xc0, 0xc0}
+	bytes, err := encodeToBytes(header)
+	require.NoError(t, err)
+	require.Equal(t, expectedBytes, bytes)
+}
+
 // Test that encryptionBlockV2 encodes and decodes properly.
 func TestEncryptionBlockV2RoundTrip(t *testing.T) {
 	isFinal := false

--- a/specs/saltpack_encryption_v1.md
+++ b/specs/saltpack_encryption_v1.md
@@ -70,6 +70,9 @@ An encrypted message is a series of concatenated MessagePack objects. The first
 is a header packet, followed by any number of non-empty payload packets, and
 finally an empty payload packet.
 
+When encoding strings, byte arrays, or arrays, pick the MessagePack
+encoding that will use the fewest number of bytes.
+
 ### Header Packet
 The header packet is a MessagePack array with these contents:
 

--- a/specs/saltpack_encryption_v1.md
+++ b/specs/saltpack_encryption_v1.md
@@ -86,9 +86,11 @@ The header packet is a MessagePack array with these contents:
 
 - The **format name** is the string "saltpack".
 - The **version** is a list of the major and minor versions, currently
-  `[1, 0]`.
-- The **mode** is the number 0, for encryption. (1 and 2 are attached and
-  detached signing.)
+  `[1, 0]`, both encoded as
+  [positive fixnums](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+- The **mode** is the number 0, for encryption, encoded as a
+[positive fixnum](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+  (1 and 2 are attached and detached signing.)
 - The **ephemeral public key** is a NaCl public encryption key, 32 bytes. The
   ephemeral keypair is generated at random by the sender and only used for one
   message.

--- a/specs/saltpack_encryption_v2.md
+++ b/specs/saltpack_encryption_v2.md
@@ -61,6 +61,9 @@ objects](https://github.com/msgpack/msgpack/blob/master/spec.md). The first is
 a header packet, followed by one or more payload packets, the last of which is
 indicated with a final packet flag.
 
+When encoding strings, byte arrays, or arrays, pick the MessagePack
+encoding that will use the fewest number of bytes.
+
 ### Header Packet
 The header packet is a MessagePack array with these contents:
 

--- a/specs/saltpack_encryption_v2.md
+++ b/specs/saltpack_encryption_v2.md
@@ -77,9 +77,11 @@ The header packet is a MessagePack array with these contents:
 
 - The **format name** is the string "saltpack".
 - The **version** is a list of the major and minor versions, currently
-  `[2, 0]`.
-- The **mode** is the number 0, for encryption. (1 and 2 are attached and
-  detached signing, and 3 is signcryption.)
+  `[2, 0]`, both encoded as
+  [positive fixnums](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+- The **mode** is the number 0, for encryption, encoded as a
+[positive fixnum](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+  (1 and 2 are attached and detached signing, and 3 is signcryption.)
 - The **ephemeral public key** is a NaCl public encryption key, 32 bytes. The
   ephemeral keypair is generated at random by the sender and only used for one
   message.

--- a/specs/saltpack_signcryption_v2.md
+++ b/specs/saltpack_signcryption_v2.md
@@ -72,9 +72,12 @@ The header packet is a MessagePack array with these contents:
 
 - The **format name** is the string "saltpack".
 - The **version** is a list of the major and minor versions, currently
-  `[2, 0]`. Note that saltpack version 1 did not include a signcryption mode.
-- The **mode** is the number 3, for signcryption. (1 and 2 are attached and
-  detached signing, and 3 is signcryption.)
+  `[2, 0]`, both encoded as
+  [positive fixnums](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+  Note that saltpack version 1 did not include a signcryption mode.
+- The **mode** is the number 3, for signcryption, encoded as a
+[positive fixnum](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+  (1 and 2 are attached and detached signing, and 3 is signcryption.)
 - The **ephemeral public key** is a NaCl public encryption key, 32 bytes. The
   ephemeral keypair is generated at random by the sender and only used for one
   message.

--- a/specs/saltpack_signcryption_v2.md
+++ b/specs/saltpack_signcryption_v2.md
@@ -56,6 +56,9 @@ objects](https://github.com/msgpack/msgpack/blob/master/spec.md). The first is
 a header packet, followed by one or more payload packets, the last of which is
 indicated with a final packet flag.
 
+When encoding strings, byte arrays, or arrays, pick the MessagePack
+encoding that will use the fewest number of bytes.
+
 ### Header Packet
 The header packet is a MessagePack array with these contents:
 

--- a/specs/saltpack_signing_v1.md
+++ b/specs/saltpack_signing_v1.md
@@ -48,9 +48,11 @@ header packet is a MessagePack array that looks like this:
 ```
 
 - **format name** is the string "saltpack".
-- **version** is a list of the major and minor versions, currently `[1, 0]`.
-- **mode** is the number 1, for attached signing. (0 is encryption, and 2 is
-  detached signing.)
+- **version** is a list of the major and minor versions, currently `[1, 0]`, both encoded as
+  [positive fixnums](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+- **mode** is the number 1, for attached signing, encoded as a
+[positive fixnum](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+  (0 is encryption, and 2 is detached signing.)
 - **sender public key** is the sender's long-term NaCl signing public key, 32 bytes.
 - **nonce** is 32 random bytes.
 

--- a/specs/saltpack_signing_v1.md
+++ b/specs/saltpack_signing_v1.md
@@ -33,6 +33,9 @@ attacker could predict in advance.
 
 ## Attached Implementation
 
+When encoding strings, byte arrays, or arrays, pick the MessagePack
+encoding that will use the fewest number of bytes.
+
 An attached signature is a header packet, followed by any number of non-empty
 payload packets, followed by an empty payload packet. An attached signing
 header packet is a MessagePack array that looks like this:

--- a/specs/saltpack_signing_v2.md
+++ b/specs/saltpack_signing_v2.md
@@ -45,9 +45,12 @@ this:
 ```
 
 - **format name** is the string "saltpack".
-- **version** is a list of the major and minor versions, currently `[2, 0]`.
-- **mode** is the number 1, for attached signing. (0 is encryption, 2 is
-  detached signing, and 3 is signcryption.)
+- **version** is a list of the major and minor versions, currently
+  `[2, 0]`, both encoded as
+  [positive fixnums](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+- **mode** is the number 1, for attached signing, encoded as a
+  [positive fixnum](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family).
+  (0 is encryption, 2 is detached signing, and 3 is signcryption.)
 - **sender public key** is the sender's long-term NaCl signing public key, 32 bytes.
 - **nonce** is 32 random bytes.
 

--- a/specs/saltpack_signing_v2.md
+++ b/specs/saltpack_signing_v2.md
@@ -28,6 +28,9 @@ attacker could predict in advance.
 
 ## Attached Implementation
 
+When encoding strings, byte arrays, or arrays, pick the MessagePack
+encoding that will use the fewest number of bytes.
+
 An attached signature is a header packet, followed by any number of non-empty
 payload packets, followed by an empty payload packet. An attached signing
 header packet is a [MessagePack


### PR DESCRIPTION
MessagePack has some ambiguity in encoding numbers, so clarify
that the version numbers and mode should be encoded as positive fixnums.

Also clarify ambiguity re. encoding strings, bytes arrays, and arrays.

Also add tests.