### PR TITLE
Add GetRaw{Public,Secret}Key functions

### DIFF
--- a/basic/key.go
+++ b/basic/key.go
@@ -85,6 +85,16 @@ func (k SecretKey) GetPublicKey() saltpack.BoxPublicKey {
 	return k.pub
 }
 
+// GetRawPublicKey returns the raw public key that corresponds to this secret key.
+func (k SecretKey) GetRawPublicKey() *[32]byte {
+	return (*[32]byte)(&k.pub.RawBoxKey)
+}
+
+// GetRawSecretKey returns the raw secret key.
+func (k SecretKey) GetRawSecretKey() *[32]byte {
+	return (*[32]byte)(&k.sec)
+}
+
 // Precompute computes a shared key with the passed public key.
 func (k SecretKey) Precompute(peer saltpack.BoxPublicKey) saltpack.BoxPrecomputedSharedKey {
 	var res PrecomputedSharedKey
@@ -256,6 +266,16 @@ func (k SigningPublicKey) ToKID() []byte {
 // secret signing key
 func (k SigningSecretKey) GetPublicKey() saltpack.SigningPublicKey {
 	return k.pub
+}
+
+// GetRawPublicKey returns the raw public key that corresponds to this secret key.
+func (k SigningSecretKey) GetRawPublicKey() *[ed25519.PublicKeySize]byte {
+	return (*[ed25519.PublicKeySize]byte)(&k.pub)
+}
+
+// GetRawSecretKey returns the raw secret key.
+func (k SigningSecretKey) GetRawSecretKey() *[ed25519.PrivateKeySize]byte {
+	return (*[ed25519.PrivateKeySize]byte)(&k.sec)
 }
 
 // Verify runs the NaCl verification routine on the given msg / sig

--- a/basic/key_test.go
+++ b/basic/key_test.go
@@ -108,6 +108,30 @@ func testBasicSign(t *testing.T, version saltpack.Version) {
 	}
 }
 
+func TestGetRawKeys(t *testing.T) {
+	kr := NewKeyring()
+	k1, err := kr.GenerateSigningKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(k1.GetRawSecretKey()[:], k1.sec[:]) {
+		t.Fatal("signing secret key mismatch")
+	}
+	if !bytes.Equal(k1.GetRawPublicKey()[:], k1.pub[:]) {
+		t.Fatal("signing public key mismatch")
+	}
+	k2, err := kr.GenerateBoxKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(k2.GetRawSecretKey()[:], k2.sec[:]) {
+		t.Fatal("box secret key mismatch")
+	}
+	if !bytes.Equal(k2.GetRawPublicKey()[:], k2.pub.RawBoxKey[:]) {
+		t.Fatal("box public key mismatch")
+	}
+}
+
 func TestKeyBasic(t *testing.T) {
 	tests := []func(*testing.T, saltpack.Version){
 		testBasicBox,


### PR DESCRIPTION
This should allow retrieving the secret (and public) keys from `SecretKey` and `SigningSecretKey`; and closes #62.  

Initially I wanted to return `RawBoxKey`s, but the `SigningSecretKey.sec` is a `[64]byte` and I didn't want one of the functions to return a completely different type.

@oconnor663 if you have any ideas for a better interface please do share them and I can fix this.

Thank you.