### PR TITLE
Various improvements

### DIFF
--- a/armor62.go
+++ b/armor62.go
@@ -44,15 +44,23 @@ func Armor62Seal(plaintext []byte, typ MessageType, brand string) (string, error
 
 // NewArmor62DecoderStream is used to decode input base62-armoring format. It returns
 // a stream you can read from, and also a Frame you can query to see what the open/close
-// frame markers were.
-func NewArmor62DecoderStream(r io.Reader) (io.Reader, Frame, error) {
-	return newArmorDecoderStream(r, Armor62Params)
+// frame markers were. hc and fc are optional and can be nil.
+func NewArmor62DecoderStream(r io.Reader, hc HeaderChecker, fc FrameChecker) (io.Reader, Frame, error) {
+	return newArmorDecoderStream(r, Armor62Params, hc, fc)
 }
 
 // Armor62Open runs armor stream decoding, but on a string, and it outputs
-// a string.
+// a string. It does not do any validation on the header and footer.
+// Deprecated: user Armor62OpenWithValidation instead.
 func Armor62Open(msg string) (body []byte, header string, footer string, err error) {
-	return armorOpen(msg, Armor62Params)
+	body, _, header, footer, err = Armor62OpenWithValidation(msg, nil, nil)
+	return body, header, footer, err
+}
+
+// Armor62OpenWithValidation runs armor stream decoding, but on a string, and it outputs
+// a string. It validates header and footer with the provided checkers (which are optional and can be nil).
+func Armor62OpenWithValidation(msg string, hc HeaderChecker, fc FrameChecker) (body []byte, brand string, header string, footer string, err error) {
+	return armorOpen(msg, Armor62Params, hc, fc)
 }
 
 // CheckArmor62Frame checks that the frame matches our standard

--- a/armor62_encrypt_test.go
+++ b/armor62_encrypt_test.go
@@ -43,14 +43,12 @@ func testDearmor62DecryptSlowReader(t *testing.T, version Version) {
 	ciphertext, err := EncryptArmor62Seal(version, msg, sndr, receivers, ourBrand)
 	require.NoError(t, err)
 
-	_, dec, frame, err := NewDearmor62DecryptStream(SingleVersionValidator(version), &slowReader{[]byte(ciphertext)}, kr)
+	_, dec, brand, err := NewDearmor62DecryptStream(SingleVersionValidator(version), &slowReader{[]byte(ciphertext)}, kr)
 	require.NoError(t, err)
+	brandCheck(t, brand)
 
 	plaintext, err := ioutil.ReadAll(dec)
 	require.NoError(t, err)
-	brand, err := CheckArmor62Frame(frame, MessageTypeEncryption)
-	require.NoError(t, err)
-	brandCheck(t, brand)
 
 	require.Equal(t, msg, plaintext)
 }

--- a/armor62_verify.go
+++ b/armor62_verify.go
@@ -9,38 +9,52 @@ import (
 	"io/ioutil"
 )
 
+var (
+	armor62SignatureHeaderChecker HeaderChecker = func(header string) (string, error) {
+		return parseFrame(header, MessageTypeAttachedSignature, headerMarker)
+	}
+	armor62SignatureFrameChecker FrameChecker = func(header, footer string) (string, error) {
+		return CheckArmor62(header, footer, MessageTypeAttachedSignature)
+	}
+	armor62DetachedSignatureHeaderChecker HeaderChecker = func(header string) (string, error) {
+		return parseFrame(header, MessageTypeDetachedSignature, headerMarker)
+	}
+	armor62DetachedSignatureFrameChecker FrameChecker = func(header, footer string) (string, error) {
+		return CheckArmor62(header, footer, MessageTypeDetachedSignature)
+	}
+)
+
 // NewDearmor62VerifyStream creates a stream that consumes data from reader
 // r.  It returns the signer's public key and a reader that only
 // contains verified data.  If the signer's key is not in keyring,
 // it will return an error. It expects the data it reads from r to
 // be armor62-encoded.
-func NewDearmor62VerifyStream(versionValidator VersionValidator, r io.Reader, keyring SigKeyring) (skey SigningPublicKey, vs io.Reader, frame Frame, err error) {
-	dearmored, frame, err := NewArmor62DecoderStream(r)
+func NewDearmor62VerifyStream(versionValidator VersionValidator, r io.Reader, keyring SigKeyring) (skey SigningPublicKey, vs io.Reader, brand string, err error) {
+	dearmored, frame, err := NewArmor62DecoderStream(r, armor62SignatureHeaderChecker, armor62SignatureFrameChecker)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, "", err
 	}
 	skey, vs, err = NewVerifyStream(versionValidator, dearmored, keyring)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, "", err
 	}
-	return skey, vs, frame, nil
+	if brand, err = frame.GetBrand(); err != nil {
+		return nil, nil, "", err
+	}
+	return skey, vs, brand, nil
 }
 
 // Dearmor62Verify checks the signature in signedMsg.  It returns the
 // signer's public key and a verified message.  It expects
 // signedMsg to be armor62-encoded.
 func Dearmor62Verify(versionValidator VersionValidator, signedMsg string, keyring SigKeyring) (skey SigningPublicKey, verifiedMsg []byte, brand string, err error) {
-	skey, stream, frame, err := NewDearmor62VerifyStream(versionValidator, bytes.NewBufferString(signedMsg), keyring)
+	skey, stream, brand, err := NewDearmor62VerifyStream(versionValidator, bytes.NewBufferString(signedMsg), keyring)
 	if err != nil {
 		return nil, nil, "", err
 	}
 
 	verifiedMsg, err = ioutil.ReadAll(stream)
 	if err != nil {
-		return nil, nil, "", err
-	}
-
-	if brand, err = CheckArmor62Frame(frame, MessageTypeAttachedSignature); err != nil {
 		return nil, nil, "", err
 	}
 
@@ -52,11 +66,8 @@ func Dearmor62Verify(versionValidator VersionValidator, signedMsg string, keyrin
 // and that the public key for the signer is in keyring. It returns
 // the signer's public key.
 func Dearmor62VerifyDetachedReader(versionValidator VersionValidator, r io.Reader, signature string, keyring SigKeyring) (skey SigningPublicKey, brand string, err error) {
-	dearmored, header, footer, err := Armor62Open(signature)
+	dearmored, brand, _, _, err := Armor62OpenWithValidation(signature, armor62DetachedSignatureHeaderChecker, armor62DetachedSignatureFrameChecker)
 	if err != nil {
-		return nil, "", err
-	}
-	if brand, err = CheckArmor62(header, footer, MessageTypeDetachedSignature); err != nil {
 		return nil, "", err
 	}
 	skey, err = VerifyDetachedReader(versionValidator, r, dearmored, keyring)

--- a/armor_test.go
+++ b/armor_test.go
@@ -100,7 +100,7 @@ func TestSlowReader(t *testing.T) {
 	a, err := Armor62Seal(m, MessageTypeEncryption, ourBrand)
 	require.NoError(t, err)
 	sr.buf = []byte(a)
-	dec, frame, err := NewArmor62DecoderStream(&sr)
+	dec, frame, err := NewArmor62DecoderStream(&sr, nil, nil)
 	require.NoError(t, err)
 	m2, err := ioutil.ReadAll(dec)
 	require.NoError(t, err)

--- a/classify_and_decrypt.go
+++ b/classify_and_decrypt.go
@@ -1,0 +1,269 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/keybase/saltpack/encoding/basex"
+
+	"github.com/keybase/go-codec/codec"
+)
+
+const (
+	// To decide if a byte slice might contain a valild header of a saltpack message, and identify its type, we need to consider at most:
+	// - 1 byte for bin tag at the beginning
+	// - at most 4 bytes for the bin length (i.e. the length of the binary encoded header)
+	// - at most 5 bytes to determine how many parts the header consists of (we expect 6 parts, but newer versions of saltpack might add more, which we would ignore as per the spec)
+	// - 9 bytes for the format name
+	// - 3 bytes for the version number
+	// - 1 byte for the message type
+	// In the common case less might be enough, but this makes the code simpler, and 23 bytes is not that much anyways.
+	minLengthToIdentifyBinarySaltpack int = 23
+)
+
+// IsSaltpackBinary peeks into the provided bufio.Reader to determine whether it encodes a binary saltpack message.
+// It does not consume any of the reader's bytes (whose buffer length must be at least minLengthToIdentifyBinarySaltpack). It returns a non nil error if the buffer
+// size of the reader is not large enough (ErrShortSliceOrBuffer), or if the stream does not appear to contain a binary
+// saltpack message. If err is nil, msgType will return the type of the encoded message, but this does *NOT* guarantee that the
+// rest of the message is well formed.
+func IsSaltpackBinary(stream *bufio.Reader) (msgType MessageType, version Version, err error) {
+
+	if stream.Size() < minLengthToIdentifyBinarySaltpack {
+		return MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+	}
+
+	b, err := stream.Peek(minLengthToIdentifyBinarySaltpack)
+	if err != nil {
+		return MessageTypeUnknown, Version{}, err
+	}
+	return IsSaltpackBinarySlice(b)
+}
+
+// IsSaltpackBinarySlice tries to determine if the input slice encodes the beginning of a binary saltpack message. It returns a non nil error if the slice is not
+// long enough to make this determination, or if it does not appear to contain a binary saltpack message. If err is nil, msgType
+// will return the type of the encoded message, but this does *NOT* guarantee that the rest of the message is well formed.
+func IsSaltpackBinarySlice(b []byte) (msgType MessageType, version Version, err error) {
+
+	// To avoid decoding the whole header, part of the messagepack decoding is done manually
+	// instead of through go-codec. See https://github.com/msgpack/msgpack/blob/master/spec.md
+	// for details on the encoding.
+
+	if len(b) < minLengthToIdentifyBinarySaltpack {
+		return MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+	}
+
+	// The header is double-encoded, so we need to skip the "bin" tag at the front to
+	// get at the encoded header array.
+	var binTagBytesToSkip int
+	if b[0] == 0xc4 {
+		binTagBytesToSkip = 2
+	} else if b[0] == 0xc5 {
+		binTagBytesToSkip = 3
+	} else if b[0] == 0xc6 {
+		binTagBytesToSkip = 5
+	} else {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+
+	// The header should be a msg pack encoded array: verify it is, that it has at least three elements, and
+	// note how many bytes to skip to point to its first element.
+	arrayTagByte := b[binTagBytesToSkip]
+	var arrayTagBytesToSkip int
+	if 0x93 <= arrayTagByte && arrayTagByte <= 0x9f {
+		arrayTagBytesToSkip = 1
+	} else if arrayTagByte == 0xdc {
+		arrayTagBytesToSkip = 3
+	} else if arrayTagByte == 0xdd {
+		arrayTagBytesToSkip = 5
+	} else {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+
+	// Devode the first 3 elements of the header, and use them to classify the message.
+	var mh codec.MsgpackHandle
+	decoder := codec.NewDecoderBytes(b[binTagBytesToSkip+arrayTagBytesToSkip:], &mh)
+	var formatName string
+
+	if err := decoder.Decode(&formatName); err != nil {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	if formatName != FormatName {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	if err := decoder.Decode(&version); err != nil {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	if err := decoder.Decode(&msgType); err != nil {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	switch msgType {
+	case MessageTypeEncryption, MessageTypeSigncryption, MessageTypeAttachedSignature, MessageTypeDetachedSignature:
+		return msgType, version, nil
+	default:
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+}
+
+// IsSaltpackArmored peeks into the provided bufio.Reader to determine whether it encodes an ASCII-armored saltpack message.
+// It does not consume any of the reader's bytes. The buffer size of the reader must be sufficient to contain the header frame plus
+// the first Base62 encoded block of the payload. It returns a non nil error if the buffer
+// size of the reader is not large enough to make this determination (ErrShortSliceOrBuffer), or if the stream does not appear to contain a valid
+// saltpack message. If err is nil, then the brand, version and expected type of the message will be returned, but this does *NOT* guarantee that the
+// rest of the message is well formed.
+func IsSaltpackArmored(stream *bufio.Reader) (brand string, msgType MessageType, ver Version, err error) {
+	buf, err := stream.Peek(stream.Size())
+	if (err != nil && err != io.EOF) || len(buf) == 0 {
+		return "", MessageTypeUnknown, ver, err
+	}
+
+	return IsSaltpackArmoredPrefix(string(buf))
+}
+
+// IsSaltpackArmored tries to determine whether the string is the prefix of a valid ASCII-armored saltpack message.
+// The prefix must be large enough to contain the header frame plus the first Base62 encoded block of the payload. It returns a non nil error if the buffer
+// size of the reader is not large enough to make this determination (ErrShortSliceOrBuffer), or if the stream does not appear to contain a valid
+// saltpack message. If err is nil, then the brand, version and expected type of the message will be returned, but this does *NOT* guarantee that the
+// rest of the message is well formed.
+func IsSaltpackArmoredPrefix(pref string) (brand string, messageType MessageType, ver Version, err error) {
+	// replace blocks of characters in the set [>\n\r\t ] with a single space, so that the next regexp is simpler
+	re := regexp.MustCompile("[>\n\r\t ]+")
+	s := strings.TrimSpace(re.ReplaceAllString(pref, " "))
+
+	headerRegExpSt := "^BEGIN (?:([a-zA-Z0-9]+) )?SALTPACK (" + EncryptionArmorString + "|" + SignedArmorString + "|" + DetachedSignatureArmorString + ") ?\\.([a-zA-Z0-9 ]*)"
+	headerRegExp := regexp.MustCompile(headerRegExpSt)
+
+	m := headerRegExp.FindStringSubmatch(s)
+	if m == nil || len(m) == 0 {
+		// Matches at most five words
+		if !regexp.MustCompile("^([a-zA-Z0-9]+ ?){0,5}$").MatchString(s) {
+			return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+		}
+
+		strs := strings.Split(s, " ")
+
+		switch len(strs) {
+		case 1:
+			if strings.HasPrefix(string(headerMarker), strs[0]) {
+				return "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+			}
+			return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+		case 2:
+			if string(headerMarker) == strs[0] {
+				return "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+			}
+			return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+		case 3, 4, 5:
+			// more processing needed.
+		default:
+			panic("logic error in ClassifyStream")
+		}
+
+		headerWithoutBrand := strings.Join(append([]string{strs[0]}, strs[2:]...), " ")
+
+		if strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+EncryptionArmorString, headerWithoutBrand) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+SignedArmorString, headerWithoutBrand) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+DetachedSignatureArmorString, headerWithoutBrand) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+EncryptionArmorString, s) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+SignedArmorString, s) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+DetachedSignatureArmorString, s) {
+			return "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+		}
+		return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+
+	brand = m[1]
+	headerArmorType := m[2] // can be one of SignedArmorString, DetachedSignatureArmorString, EncryptionArmorString
+
+	dec, err := basex.Base62StdEncoding.DecodeString(m[3])
+	// This is not a prefix free encoding, so we need to decode a full codeword (32 bytes) to make sure we are not interpreting
+	// a truncated block as if it was a short block. Moreover, we only need one codeword, so if an error is returned but a codeword
+	// was decoded, the error can be ignored.
+	if len(dec) < 32 {
+		if err == basex.ErrInvalidEncodingLength || err == nil {
+			return "", MessageTypeUnknown, ver, ErrShortSliceOrBuffer
+		}
+		return "", MessageTypeUnknown, ver, ErrNotASaltpackMessage
+	}
+
+	messageType, ver, err = IsSaltpackBinarySlice(dec)
+	if err != nil {
+		return "", MessageTypeUnknown, ver, err
+	}
+
+	// ensure that the type of the armor matches the type of the inner header
+	if (messageType == MessageTypeSigncryption && headerArmorType != EncryptionArmorString) ||
+		(messageType == MessageTypeEncryption && headerArmorType != EncryptionArmorString) ||
+		(messageType == MessageTypeAttachedSignature && headerArmorType != SignedArmorString) ||
+		(messageType == MessageTypeDetachedSignature && headerArmorType != DetachedSignatureArmorString) {
+		return "", MessageTypeUnknown, ver, ErrNotASaltpackMessage
+	}
+
+	return m[1], messageType, ver, nil
+}
+
+// ClassifyStream peeks at the beginning of a stream and checks wether it seems to contain a valid
+// saltpack message (either armored or not).
+// The buffer size must be at least minLengthToIdentifyBinarySaltpack bytes for binary messages, and large
+// enough that if there is a header frame (i.e. "BEGIN FOO."), plus the first
+// base62 encoded block (43 characters) of the steam (the default buffer size of bufio.Reader
+// will be enough in most cases). Otherwise, ErrShortSliceOrBuffer will be returned.
+// If err is nil, then the expected message type and version will be returned, as well as a booleand
+// indicating if the message is ASCII-armored and the brand (for armored messages only).
+// Note this classification is just a guess based on the beginning of the stream, and it does not
+// guarantee that the message is valid or well formed.
+func ClassifyStream(stream *bufio.Reader) (isArmored bool, brand string, messageType MessageType, ver Version, err error) {
+	brand, messageType, ver, err = IsSaltpackArmored(stream)
+	if err == nil {
+		return true, brand, messageType, ver, err
+	} else if err == ErrShortSliceOrBuffer {
+		return false, "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+	}
+	messageType, ver, err = IsSaltpackBinary(stream)
+	if err == nil {
+		return false, "", messageType, ver, err
+	}
+	return false, "", MessageTypeUnknown, Version{}, err
+}
+
+// ClassifyEncryptedStreamAndMakeDecoder takes as input an io.Reader (containing an encrypted saltpack stream),
+// a SigncryptKeyring containing the keys to use for decryption, and a SymmetricKeyResolver (used to map an
+// identifiers to symmetric keys in an application specific way). It classifies the encrypted stream
+// (encryption vs signcryption mode and binary vs armored format) and returns a reader for the decoded stream,
+// as well as some informtation about the stream. The brand is only returned for armored ciphertexts, mki only
+// for encryption-mode ciphertext, senderPublic only for signcryption-mode ciphertexts.
+func ClassifyEncryptedStreamAndMakeDecoder(source io.Reader, decryptionKeyring SigncryptKeyring, keyResolver SymmetricKeyResolver) (
+	plainsource io.Reader, msgType MessageType, mki *MessageKeyInfo, senderPublic SigningPublicKey, isArmored bool, brand string, ver Version, err error) {
+	stream := bufio.NewReader(source)
+
+	isArmored, _, msgType, ver, err = ClassifyStream(stream)
+	if err == ErrShortSliceOrBuffer {
+		return nil, MessageTypeUnknown, nil, nil, false, "", Version{}, ErrShortSliceOrBuffer
+	}
+	if err != nil {
+		return nil, MessageTypeUnknown, nil, nil, false, "", Version{}, ErrNotASaltpackMessage
+	}
+
+	switch msgType {
+	case MessageTypeEncryption:
+		if isArmored {
+			mki, plainsource, brand, err = NewDearmor62DecryptStream(CheckKnownMajorVersion, stream, decryptionKeyring)
+		} else {
+			mki, plainsource, err = NewDecryptStream(CheckKnownMajorVersion, stream, decryptionKeyring)
+		}
+		return plainsource, msgType, mki, nil, isArmored, brand, ver, err
+	case MessageTypeSigncryption:
+		if isArmored {
+			senderPublic, plainsource, brand, err = NewDearmor62SigncryptOpenStream(stream, decryptionKeyring, keyResolver)
+		} else {
+			senderPublic, plainsource, err = NewSigncryptOpenStream(stream, decryptionKeyring, keyResolver)
+		}
+		return plainsource, msgType, nil, senderPublic, isArmored, brand, ver, err
+	default:
+		return nil, MessageTypeUnknown, nil, nil, false, "", Version{}, ErrWrongMessageType{}
+	}
+}

--- a/classify_and_decrypt.go
+++ b/classify_and_decrypt.go
@@ -33,11 +33,10 @@ const (
 // rest of the message is well formed.
 func IsSaltpackBinary(stream *bufio.Reader) (msgType MessageType, version Version, err error) {
 
-	if stream.Size() < minLengthToIdentifyBinarySaltpack {
+	b, err := stream.Peek(minLengthToIdentifyBinarySaltpack)
+	if err == bufio.ErrBufferFull {
 		return MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
 	}
-
-	b, err := stream.Peek(minLengthToIdentifyBinarySaltpack)
 	if err != nil {
 		return MessageTypeUnknown, Version{}, err
 	}

--- a/classify_and_decrypt_test.go
+++ b/classify_and_decrypt_test.go
@@ -1,0 +1,420 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSaltpackBinarySlice(t *testing.T) {
+	// Signcryption
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+	sealed, err := SigncryptSeal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	typ, ver, err := IsSaltpackBinarySlice(sealed)
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeSigncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Encryption
+	sender := boxSecretKey{
+		key: RawBoxKey{0x08},
+	}
+	receivers := []BoxPublicKey{boxPublicKey{key: RawBoxKey{0x1}}}
+	ciphertext, err := Seal(Version2(), msg, sender, receivers)
+	require.NoError(t, err)
+
+	typ, ver, err = IsSaltpackBinarySlice(ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeEncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Attached Sig
+	key := newSigPrivKey(t)
+	asig, err := Sign(Version2(), msg, key)
+	require.NoError(t, err)
+
+	typ, ver, err = IsSaltpackBinarySlice(asig)
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeAttachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Detached Sig
+	dsig, err := SignDetached(Version2(), msg, key)
+	require.NoError(t, err)
+
+	typ, ver, err = IsSaltpackBinarySlice(dsig)
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeDetachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// short message
+	typ, ver, err = IsSaltpackBinarySlice(dsig[0:5])
+	require.Equal(t, err, ErrShortSliceOrBuffer)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+
+	// invalid messages
+	invalid := append([]byte{}, dsig...)
+	invalid[0] = 0xff
+	typ, ver, err = IsSaltpackBinarySlice(invalid)
+	require.Equal(t, ErrNotASaltpackMessage, err)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+}
+
+func TestIsSaltpackBinary(t *testing.T) {
+	// Signcryption
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+	sealed, err := SigncryptSeal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	typ, ver, err := IsSaltpackBinary(bufio.NewReader(bytes.NewReader(sealed)))
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeSigncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Encryption
+	sender := boxSecretKey{
+		key: RawBoxKey{0x08},
+	}
+	receivers := []BoxPublicKey{boxPublicKey{key: RawBoxKey{0x1}}}
+	ciphertext, err := Seal(Version2(), msg, sender, receivers)
+	require.NoError(t, err)
+
+	typ, ver, err = IsSaltpackBinary(bufio.NewReader(bytes.NewReader(ciphertext)))
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeEncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Attached Sig
+	key := newSigPrivKey(t)
+	asig, err := Sign(Version2(), msg, key)
+	require.NoError(t, err)
+
+	typ, ver, err = IsSaltpackBinary(bufio.NewReader(bytes.NewReader(asig)))
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeAttachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Detached Sig
+	dsig, err := SignDetached(Version2(), msg, key)
+	require.NoError(t, err)
+
+	typ, ver, err = IsSaltpackBinary(bufio.NewReader(bytes.NewReader(dsig)))
+	require.NoError(t, err)
+	require.Equal(t, MessageTypeDetachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// short message
+	typ, ver, err = IsSaltpackBinary(bufio.NewReaderSize(bytes.NewReader(dsig), 5))
+	require.Equal(t, ErrShortSliceOrBuffer, err)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+
+	// invalid messages
+	invalid := append([]byte{}, dsig...)
+	invalid[0] = 0xff
+	typ, ver, err = IsSaltpackBinary(bufio.NewReader(bytes.NewReader(invalid)))
+	require.Equal(t, ErrNotASaltpackMessage, err)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+}
+
+func TestIsSaltpackArmored(t *testing.T) {
+	// Signcryption
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealedStr, err := SigncryptArmor62Seal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil, ourBrand)
+	require.NoError(t, err)
+
+	brand, typ, ver, err := IsSaltpackArmored(bufio.NewReader(bytes.NewReader([]byte(sealedStr))))
+	require.NoError(t, err)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeSigncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Encryption
+	sender := boxSecretKey{
+		key: RawBoxKey{0x08},
+	}
+	receivers := []BoxPublicKey{boxPublicKey{key: RawBoxKey{0x1}}}
+
+	ciphertextStr, err := EncryptArmor62Seal(Version2(), msg, sender, receivers, ourBrand)
+	require.NoError(t, err)
+
+	brand, typ, ver, err = IsSaltpackArmored(bufio.NewReader(bytes.NewReader([]byte(ciphertextStr))))
+	require.NoError(t, err)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeEncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Attached Sig
+	key := newSigPrivKey(t)
+	asigStr, err := SignArmor62(Version2(), msg, key, ourBrand)
+	require.NoError(t, err)
+
+	brand, typ, ver, err = IsSaltpackArmored(bufio.NewReader(strings.NewReader(asigStr)))
+	require.NoError(t, err)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeAttachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Detached Sig
+	dsigStr, err := SignDetachedArmor62(Version2(), msg, key, ourBrand)
+	require.NoError(t, err)
+
+	brand, typ, ver, err = IsSaltpackArmored(bufio.NewReader(strings.NewReader(dsigStr)))
+	require.NoError(t, err)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeDetachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// short message
+	brand, typ, ver, err = IsSaltpackArmored(bufio.NewReaderSize(strings.NewReader(dsigStr), 5))
+	require.Equal(t, ErrShortSliceOrBuffer, err)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+
+	// invalid messages
+	invalid := append([]byte{}, []byte(dsigStr)...)
+	invalid[0] = 0xff
+	brand, typ, ver, err = IsSaltpackArmored(bufio.NewReader(bytes.NewReader(invalid)))
+	require.Equal(t, err, ErrNotASaltpackMessage)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+}
+
+func TestIsSaltpackArmoredShortArmor(t *testing.T) {
+	// Signcryption
+	msg := []byte("hello world hello world hello world hello world hello world hello world hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealedStr, err := SigncryptArmor62Seal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil, ourBrand)
+	require.NoError(t, err)
+
+	// The number 83 directly depends on the length of the header frame, the number of spaces, and the base62 block length
+	// for this specific message.
+	for i := 0; i < 83; i++ {
+		_, _, _, err := IsSaltpackArmoredPrefix(sealedStr[:i])
+		require.Equalf(t, ErrShortSliceOrBuffer, err, "Expected ErrShortSliceOrBuffer for i=%v, instead got: %T, %v", i, err, err)
+	}
+	for i := 84; i < len(sealedStr); i++ {
+		_, _, _, err := IsSaltpackArmoredPrefix(sealedStr[:i])
+		require.NoErrorf(t, err, "Unexpected error for i = %v: %T, %v", i, err, err)
+	}
+}
+
+func TestClassifyStream(t *testing.T) {
+	// Signcryption
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+	sealed, err := SigncryptSeal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err := ClassifyStream(bufio.NewReader(bytes.NewReader(sealed)))
+	require.NoError(t, err)
+	require.False(t, armored)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeSigncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	sealedStr, err := SigncryptArmor62Seal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil, ourBrand)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(bytes.NewReader([]byte(sealedStr))))
+	require.NoError(t, err)
+	require.True(t, armored)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeSigncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Encryption
+	sender := boxSecretKey{
+		key: RawBoxKey{0x08},
+	}
+	receivers := []BoxPublicKey{boxPublicKey{key: RawBoxKey{0x1}}}
+	ciphertext, err := Seal(Version2(), msg, sender, receivers)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(bytes.NewReader(ciphertext)))
+	require.NoError(t, err)
+	require.False(t, armored)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeEncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	ciphertextStr, err := EncryptArmor62Seal(Version2(), msg, sender, receivers, ourBrand)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(bytes.NewReader([]byte(ciphertextStr))))
+	require.NoError(t, err)
+	require.True(t, armored)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeEncryption, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Attached Sig
+	key := newSigPrivKey(t)
+	asig, err := Sign(Version2(), msg, key)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(bytes.NewReader(asig)))
+	require.NoError(t, err)
+	require.False(t, armored)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeAttachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	asigStr, err := SignArmor62(Version2(), msg, key, ourBrand)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(strings.NewReader(asigStr)))
+	require.NoError(t, err)
+	require.True(t, armored)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeAttachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	// Detached Sig
+	dsig, err := SignDetached(Version2(), msg, key)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(bytes.NewReader(dsig)))
+	require.NoError(t, err)
+	require.False(t, armored)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeDetachedSignature, typ)
+	require.Equal(t, Version2(), ver)
+
+	dsigStr, err := SignDetachedArmor62(Version2(), msg, key, ourBrand)
+	require.NoError(t, err)
+
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(strings.NewReader(dsigStr)))
+	require.NoError(t, err)
+	require.True(t, armored)
+	require.Equal(t, ourBrand, brand)
+	require.Equal(t, MessageTypeDetachedSignature, typ)
+
+	// short message
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReaderSize(bytes.NewReader(dsig), 5))
+	require.Equal(t, ErrShortSliceOrBuffer, err)
+	require.False(t, armored)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+
+	// invalid messages
+	invalid := append([]byte{}, dsig...)
+	invalid[0] = 0xff
+	armored, brand, typ, ver, err = ClassifyStream(bufio.NewReader(bytes.NewReader(invalid)))
+	require.Equal(t, err, ErrNotASaltpackMessage)
+	require.False(t, armored)
+	require.Equal(t, "", brand)
+	require.Equal(t, MessageTypeUnknown, typ)
+	require.Equal(t, Version{}, ver)
+}
+
+func TestClassifyEncryptedStreamAndMakeDecoder(t *testing.T) {
+	// Signcryption
+	msg := []byte("hello world")
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+	sealed, err := SigncryptSeal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	plainSource, msgType, mki, senderPublic, isArmored, brand, ver, err := ClassifyEncryptedStreamAndMakeDecoder(bytes.NewReader(sealed), keyring, nil)
+	require.NoError(t, err)
+	plainString, err := ioutil.ReadAll(plainSource)
+	require.NoError(t, err)
+	require.Equal(t, msg, plainString)
+	require.Equal(t, MessageTypeSigncryption, msgType)
+	require.Nil(t, mki)
+	require.Equal(t, senderSigningPrivKey.GetPublicKey(), senderPublic)
+	require.False(t, isArmored)
+	require.Equal(t, brand, "")
+	require.Equal(t, Version2(), ver)
+
+	sealedStr, err := SigncryptArmor62Seal(msg, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil, ourBrand)
+	require.NoError(t, err)
+
+	plainSource, msgType, mki, senderPublic, isArmored, brand, ver, err = ClassifyEncryptedStreamAndMakeDecoder(bytes.NewReader([]byte(sealedStr)), keyring, nil)
+	require.NoError(t, err)
+	plainString, err = ioutil.ReadAll(plainSource)
+	require.NoError(t, err)
+	require.Equal(t, msg, plainString)
+	require.Equal(t, MessageTypeSigncryption, msgType)
+	require.Nil(t, mki)
+	require.Equal(t, senderSigningPrivKey.GetPublicKey(), senderPublic)
+	require.True(t, isArmored)
+	require.Equal(t, brand, ourBrand)
+	require.Equal(t, Version2(), ver)
+
+	// Encryption
+	sender := newBoxKey(t)
+	ciphertext, err := Seal(Version2(), msg, sender, receiverBoxKeys)
+	require.NoError(t, err)
+
+	plainSource, msgType, mki, senderPublic, isArmored, brand, ver, err = ClassifyEncryptedStreamAndMakeDecoder(bytes.NewReader(ciphertext), keyring, nil)
+	require.NoError(t, err)
+	plainString, err = ioutil.ReadAll(plainSource)
+	require.NoError(t, err)
+	require.Equal(t, msg, plainString)
+	require.Equal(t, MessageTypeEncryption, msgType)
+	require.NoError(t, err)
+	require.False(t, mki.SenderIsAnon)
+	require.False(t, mki.ReceiverIsAnon)
+	require.True(t, PublicKeyEqual(sender.GetPublicKey(), mki.SenderKey))
+	require.True(t, PublicKeyEqual(receiverBoxKeys[0], mki.ReceiverKey.GetPublicKey()))
+	require.Nil(t, senderPublic)
+	require.False(t, isArmored)
+	require.Equal(t, brand, "")
+	require.Equal(t, Version2(), ver)
+
+	ciphertextStr, err := EncryptArmor62Seal(Version2(), msg, sender, receiverBoxKeys, ourBrand)
+	require.NoError(t, err)
+
+	plainSource, msgType, mki, senderPublic, isArmored, brand, ver, err = ClassifyEncryptedStreamAndMakeDecoder(strings.NewReader(ciphertextStr), keyring, nil)
+	require.NoError(t, err)
+	plainString, err = ioutil.ReadAll(plainSource)
+	require.NoError(t, err)
+	require.Equal(t, msg, plainString)
+	require.Equal(t, MessageTypeEncryption, msgType)
+	require.NoError(t, err)
+	require.False(t, mki.SenderIsAnon)
+	require.False(t, mki.ReceiverIsAnon)
+	require.True(t, PublicKeyEqual(sender.GetPublicKey(), mki.SenderKey))
+	require.True(t, PublicKeyEqual(receiverBoxKeys[0], mki.ReceiverKey.GetPublicKey()))
+	require.Nil(t, senderPublic)
+	require.True(t, isArmored)
+	require.Equal(t, brand, ourBrand)
+	require.Equal(t, Version2(), ver)
+
+	// short message
+	plainSource, msgType, mki, senderPublic, isArmored, brand, ver, err = ClassifyEncryptedStreamAndMakeDecoder(strings.NewReader(ciphertextStr[:20]), keyring, nil)
+	require.Equal(t, ErrShortSliceOrBuffer, err)
+
+	// invalid messages
+	invalid := append([]byte{}, ciphertext...)
+	invalid[0] = 0xff
+	plainSource, msgType, mki, senderPublic, isArmored, brand, ver, err = ClassifyEncryptedStreamAndMakeDecoder(bytes.NewReader(invalid), keyring, nil)
+	require.Equal(t, ErrNotASaltpackMessage, err)
+}

--- a/const.go
+++ b/const.go
@@ -12,6 +12,12 @@ type MessageType int
 // In general, the former is one more than the latter.
 type packetSeqno uint64
 
+// MessageTypeUnknown is used by the decoding functions
+// to indicate an unknown message type or a decoding error.
+// This is NOT a constant in the saltpack spec, and is specific
+// to this library implementation.
+const MessageTypeUnknown MessageType = -1
+
 // MessageTypeEncryption is a packet type to describe an
 // encryption message.
 const MessageTypeEncryption MessageType = 0

--- a/encoding/basex/bases.go
+++ b/encoding/basex/bases.go
@@ -30,5 +30,5 @@ const base62EncodeStd = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 var Base62StdEncodingStrict = NewEncoding(base62EncodeStd, 32, "")
 
 // Base62StdEncoding is the standard 62-encoding, with a 32-byte input block and, a
-// 43-byte output block. Foreign chracters are ignored
+// 43-byte output block.
 var Base62StdEncoding = NewEncoding(base62EncodeStd, 32, "\t\n\r >")

--- a/encoding/basex/encoding.go
+++ b/encoding/basex/encoding.go
@@ -154,7 +154,7 @@ func (enc *Encoding) decode(dst []byte, src []byte) (n int, err error) {
 	for sp < len(src) {
 		di, si, err := enc.decodeBlock(dst[dp:], src[sp:], sp)
 		if err != nil {
-			return 0, err
+			return dp, err
 		}
 		sp += si
 		dp += di

--- a/errors.go
+++ b/errors.go
@@ -71,6 +71,14 @@ var (
 	// encountered that isn't both the last one and the first one
 	// (for V2 and higher), or isn't the last one (for V1).
 	ErrUnexpectedEmptyBlock = errors.New("unexpected empty block")
+
+	// ErrShortSliceOrBuffer is returned when the input slice or buffer provided
+	// is too short to determine if it is the beginning of a binary saltpack message
+	ErrShortSliceOrBuffer = errors.New("the slice or buffer is too short to tell if it is the beginning of a saltpack message")
+
+	// ErrNotASaltpackMessage is returned when the message given as input is not
+	// a valid  saltpack message
+	ErrNotASaltpackMessage = errors.New("not a saltpack message")
 )
 
 // ErrBadTag is generated when a payload hash doesn't match the hash

--- a/specs/saltpack_armor.md
+++ b/specs/saltpack_armor.md
@@ -258,14 +258,15 @@ ipsum](https://twitter.com/oconnor663/status/680171387353448448).
 The BaseX payload is surrounded ('framed') by a header and footer. Rules for parsing
 them appear here.
 
-1. Collect input up to the first period. This is the header.
+1. Collect input up to the first period. This is the header. 
 2. Assert that the header matches the regex
    ```
-   ^[>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]+[>\n\r\t ]+)?SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE|SIGNED[>\n\r\t ]+MESSAGE|DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*$
+   ^(?=.{1,512}$)[>\n\r\t ]*BEGIN[>\n\r\t ]+([a-zA-Z0-9]{1,128}[>\n\r\t ]+)?SALTPACK[>\n\r\t ]+(ENCRYPTED[>\n\r\t ]+MESSAGE|SIGNED[>\n\r\t ]+MESSAGE|DETACHED[>\n\r\t ]+SIGNATURE)[>\n\r\t ]*$
    ```
    We match against `>` for compatibility with mail clients that use it for quoting.
-   The optional word is an application name (like 'KEYBASE'). The last two words give the
-   mode of the message.
+   The optional word is an application name (like 'KEYBASE'), and cannot be 
+   longer than 128 characters. The last two words give the mode of the message.
+   The whole header cannot be longer than 512 characters.
 3. Collect input up to the second period. This is the payload. If the implementation is
    streaming, it may decode the payload before the following steps.
 4. Collect input up to the third period. This is the footer.


### PR DESCRIPTION
- Add limits to frame and brand size. 
- Introduce function to classify saltpack stream (so the keybase/client repo doesn't have to do manually).
- Make sure the input frame is always checked, no matter which decryption/verification function we use.
- Fix comment