### PR TITLE
Fix concurrent use of basex.Encoding (Crash, hang or corrupted data)

### DIFF
--- a/encoding/basex/encoding.go
+++ b/encoding/basex/encoding.go
@@ -23,7 +23,6 @@ type Encoding struct {
 	logOfBase       float64
 	baseBig         *big.Int
 	skipBytes       string
-	scratchInt      *big.Int
 }
 
 // NewEncoding returns a new Encoding defined by the given alphabet,
@@ -54,7 +53,6 @@ func NewEncoding(encoder string, base256BlockLen int, skipBytes string) *Encodin
 		logOfBase:       logOfBase,
 		baseBig:         big.NewInt(int64(base)),
 		skipBytes:       skipBytes,
-		scratchInt:      new(big.Int),
 	}
 	copy(e.encode[:], encoder)
 
@@ -186,7 +184,7 @@ var ErrInvalidEncodingLength = errors.New("invalid encoding length; either trunc
 func (enc *Encoding) decodeBlock(dst []byte, src []byte, baseOffset int) (int, int, error) {
 	si := 0 // source index
 	numGoodChars := 0
-	res := enc.scratchInt
+	res := new(big.Int)
 	res.SetUint64(0)
 
 	for i, b := range src {

--- a/encoding/basex/go_base64_test.go
+++ b/encoding/basex/go_base64_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+
 	// "reflect"
 	"strings"
 	"testing"
@@ -127,7 +128,7 @@ func TestDecode(t *testing.T) {
 
 			dbuf, err = tt.enc.DecodeString(encoded)
 			testEqual(t, "DecodeString(%q) = error %v, want %v", encoded, err, error(nil))
-			testEqual(t, "DecodeString(%q) = %q, want %q", string(dbuf), p.decoded)
+			testEqual(t, "DecodeString(%q) = %q, want %q", encoded, string(dbuf), p.decoded)
 		}
 	}
 }


### PR DESCRIPTION
The encoder will fail if you try to use it concurrently because the Encoding is keeping a "scratchInt" variable that it is mutating on decode. This is particularly gnarly because it can randomly cause the decoded data to be changed (if it doesn't crash). I've also seen it just hang the runtime as well.

I added a test case which shows a crash on concurrent use, and a fix which removes use of a scratchInt.

Nothing in the Encoding struct should be change on encode or decode since it is used as a shared instance variable.

