### PR TITLE
SymmetricKeyResolver is optional

### DIFF
--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -112,6 +112,10 @@ func (sos *signcryptOpenStream) trySharedSymmetricKeys(hdr *SigncryptionHeader, 
 		identifiers = append(identifiers, receiver.ReceiverKID)
 	}
 
+	if sos.resolver == nil {
+		return nil, nil
+	}
+
 	resolvedKeys, err := sos.resolver.ResolveKeys(identifiers)
 	if err != nil {
 		return nil, err

--- a/signcrypt_open_test.go
+++ b/signcrypt_open_test.go
@@ -47,7 +47,7 @@ func TestDecryptNoKey(t *testing.T) {
 	// Open with empty keyring
 	emptyKeyring := makeEmptyKeyring(t)
 	sender, msg, openErr := SigncryptOpen(sealed, emptyKeyring, nil)
-	require.EqualError(t, openErr, "no decryption key found for message")
+	require.Equal(t, openErr, ErrNoDecryptionKey)
 	require.Nil(t, sender)
 	require.Empty(t, msg)
 }

--- a/signcrypt_open_test.go
+++ b/signcrypt_open_test.go
@@ -35,3 +35,19 @@ func TestDecryptErrorAtEOF(t *testing.T) {
 	// message should still compare equal to the original input.
 	require.Equal(t, plaintext, msg)
 }
+
+func TestDecryptNoKey(t *testing.T) {
+	plaintext := randomMsg(t, 128)
+	keyring, receiverBoxKeys := makeKeyringWithOneKey(t)
+	senderSigningPrivKey := makeSigningKey(t, keyring)
+
+	sealed, err := SigncryptSeal(plaintext, ephemeralKeyCreator{}, senderSigningPrivKey, receiverBoxKeys, nil)
+	require.NoError(t, err)
+
+	// Open with empty keyring
+	emptyKeyring := makeEmptyKeyring(t)
+	sender, msg, openErr := SigncryptOpen(sealed, emptyKeyring, nil)
+	require.EqualError(t, openErr, "no decryption key found for message")
+	require.Nil(t, sender)
+	require.Empty(t, msg)
+}


### PR DESCRIPTION
When using signcrypt open, if you don't specify a SymmetricKeyResolver it panics.

Since the resolver is optional, we can check for nil and return, and it returns with a ErrNoDecryptionKey error as expected.