### PR TITLE
signcrypt: Fix no sender error

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -227,7 +227,7 @@ func (ds *decryptStream) processHeader(hdr *EncryptionHeader) error {
 	if !hmac.Equal(hdr.Ephemeral, ds.senderKey[:]) {
 		longLivedSenderKey := ds.ring.LookupBoxPublicKey(ds.senderKey[:])
 		if longLivedSenderKey == nil {
-			return ErrNoSenderKey
+			return ErrNoSenderKey{Sender: ds.senderKey[:]}
 		}
 		ds.mki.SenderKey = longLivedSenderKey
 	} else {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -958,7 +958,7 @@ func testNoSenderKey(t *testing.T, version Version) {
 	})
 	require.NoError(t, err)
 	_, _, err = Open(SingleVersionValidator(version), ciphertext, kr)
-	require.Equal(t, ErrNoSenderKey, err)
+	require.Equal(t, ErrNoSenderKey{Sender: sender.GetPublicKey().ToKID()}, err)
 }
 
 func testSealAndOpenTrailingGarbage(t *testing.T, version Version) {

--- a/errors.go
+++ b/errors.go
@@ -14,10 +14,6 @@ var (
 	// request with a (-1,nil) return value, and no hidden keys are found.
 	ErrNoDecryptionKey = errors.New("no decryption key found for message")
 
-	// ErrNoSenderKey indicates that on decryption/verification we couldn't find a public key
-	// for the sender.
-	ErrNoSenderKey = errors.New("no sender key found for message")
-
 	// ErrTrailingGarbage indicates that additional msgpack packets were found after the
 	// end of the encryption stream.
 	ErrTrailingGarbage = errors.New("trailing garbage found at end of message")
@@ -81,6 +77,12 @@ var (
 	ErrNotASaltpackMessage = errors.New("not a saltpack message")
 )
 
+// ErrNoSenderKey indicates that on decryption/verification we couldn't find a public key
+// for the sender.
+type ErrNoSenderKey struct {
+	Sender []byte
+}
+
 // ErrBadTag is generated when a payload hash doesn't match the hash
 // authenticator. It specifies which Packet sequence number the bad packet was
 // in.
@@ -120,6 +122,9 @@ func makeErrBadFrame(format string, args ...interface{}) error {
 	return ErrBadFrame{fmt.Sprintf(format, args...)}
 }
 
+func (e ErrNoSenderKey) Error() string {
+	return "no sender key found for message"
+}
 func (e ErrWrongMessageType) Error() string {
 	return fmt.Sprintf("Wrong saltpack message type: wanted %s, but got %s instead", e.wanted, e.received)
 }

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -213,6 +213,9 @@ func (sos *signcryptOpenStream) processBlock(payloadCiphertext []byte, isFinal b
 	// convention the signature bytes are all zeroes, but here we ignore them.
 	if !sos.senderAnonymous {
 		signatureInput := computeSigncryptionSignatureInput(sos.headerHash, nonce, isFinal, chunkPlaintext)
+		if sos.signingPublicKey == nil {
+			return nil, ErrNoSenderKey
+		}
 		sigErr := sos.signingPublicKey.Verify(signatureInput, detachedSig[:])
 		if sigErr != nil {
 			return nil, ErrBadSignature

--- a/signcrypt_open.go
+++ b/signcrypt_open.go
@@ -185,7 +185,11 @@ func (sos *signcryptOpenStream) processHeader(hdr *SigncryptionHeader) error {
 		sos.senderAnonymous = true
 	} else {
 		// regular mode, with a real signing public key
-		sos.signingPublicKey = sos.keyring.LookupSigningPublicKey(senderKeySlice)
+		spk := sos.keyring.LookupSigningPublicKey(senderKeySlice)
+		if spk == nil {
+			return ErrNoSenderKey{Sender: senderKeySlice}
+		}
+		sos.signingPublicKey = spk
 	}
 
 	return nil
@@ -213,9 +217,6 @@ func (sos *signcryptOpenStream) processBlock(payloadCiphertext []byte, isFinal b
 	// convention the signature bytes are all zeroes, but here we ignore them.
 	if !sos.senderAnonymous {
 		signatureInput := computeSigncryptionSignatureInput(sos.headerHash, nonce, isFinal, chunkPlaintext)
-		if sos.signingPublicKey == nil {
-			return nil, ErrNoSenderKey
-		}
 		sigErr := sos.signingPublicKey.Verify(signatureInput, detachedSig[:])
 		if sigErr != nil {
 			return nil, ErrBadSignature

--- a/signcrypt_open_test.go
+++ b/signcrypt_open_test.go
@@ -51,7 +51,7 @@ func TestDecryptNoSender(t *testing.T) {
 
 	// Open with only (reciever) key in keyring (not sender)
 	sender, msg, openErr := SigncryptOpen(sealed, bobKeyring, nil)
-	require.Equal(t, openErr, ErrNoSenderKey)
+	require.Equal(t, openErr, ErrNoSenderKey{Sender: aliceSigningPrivKey.GetPublicKey().ToKID()})
 	require.Nil(t, sender)
 	require.Empty(t, msg)
 

--- a/signcrypt_test.go
+++ b/signcrypt_test.go
@@ -53,7 +53,13 @@ func makeKeyringWithOneKey(t *testing.T) (*keyring, []BoxPublicKey) {
 	return keyring, receiverBoxKeys
 }
 
-func makeSigningKey(t *testing.T, keyring *keyring) *sigPrivKey {
+func makeSigningKey(t *testing.T, keyring *keyring) SigningSecretKey {
+	k := makeSigningSecretKey(t)
+	keyring.insertSigningKey(k)
+	return k
+}
+
+func makeSigningSecretKey(t *testing.T) SigningSecretKey {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +68,6 @@ func makeSigningKey(t *testing.T, keyring *keyring) *sigPrivKey {
 		public:  newSigPubKey(pub),
 		private: priv,
 	}
-	keyring.insertSigningKey(k)
 	return k
 }
 

--- a/verify.go
+++ b/verify.go
@@ -21,7 +21,7 @@ func NewVerifyStream(versionValidator VersionValidator, r io.Reader, keyring Sig
 	}
 	skey = keyring.LookupSigningPublicKey(s.header.SenderPublic)
 	if skey == nil {
-		return nil, nil, ErrNoSenderKey
+		return nil, nil, ErrNoSenderKey{Sender: s.header.SenderPublic}
 	}
 	s.publicKey = skey
 	return skey, newChunkReader(s), nil
@@ -64,7 +64,7 @@ func VerifyDetachedReader(versionValidator VersionValidator, message io.Reader, 
 	// Get the public key.
 	skey = keyring.LookupSigningPublicKey(s.header.SenderPublic)
 	if skey == nil {
-		return nil, ErrNoSenderKey
+		return nil, ErrNoSenderKey{Sender: s.header.SenderPublic}
 	}
 
 	// Compute the signed text hash, without requiring us to copy the whole

--- a/verify_test.go
+++ b/verify_test.go
@@ -92,7 +92,7 @@ func testVerifyEmptyKeyring(t *testing.T, version Version) {
 	require.NoError(t, err)
 
 	_, _, err = Verify(SingleVersionValidator(version), smsg, emptySigKeyring{})
-	require.Equal(t, ErrNoSenderKey, err)
+	require.Equal(t, ErrNoSenderKey{Sender: key.GetPublicKey().ToKID()}, err)
 }
 
 func testVerifyDetachedEmptyKeyring(t *testing.T, version Version) {
@@ -102,7 +102,7 @@ func testVerifyDetachedEmptyKeyring(t *testing.T, version Version) {
 	require.NoError(t, err)
 
 	_, err = VerifyDetached(SingleVersionValidator(version), msg, sig, emptySigKeyring{})
-	require.Equal(t, ErrNoSenderKey, err)
+	require.Equal(t, ErrNoSenderKey{Sender: key.GetPublicKey().ToKID()}, err)
 }
 
 func testVerifyErrorAtEOF(t *testing.T, version Version) {


### PR DESCRIPTION
If you try to signcrypt open and the sender signing key doesn't exist in the keyring, it panics.
Instead it should return a ErrNoSenderKey error.

We also change the ErrNoSenderKey value to a type, and include the sender bytes.
This allows clients to show to the user which sender key was missing.