### PR TITLE
Clarify ambiguity in encryption spec/example

### DIFF
--- a/specs/saltpack_encryption_v2.md
+++ b/specs/saltpack_encryption_v2.md
@@ -299,6 +299,8 @@ constructions.
 
 # payload packet
 [
+  # final flag
+  True,
   # authenticators list
   [
     # the first recipient's authenticator
@@ -307,7 +309,5 @@ constructions.
   ],
   # payload secretbox
   f991dbe030e2cfa00a640376f956c68b2d113ec6384441a1834e455acbb046ead9389826e92cb7f91cc7ab30c3d4d38ef5e84d12617f37,
-  # final flag
-  True,
 ]
 ```


### PR DESCRIPTION
From #43, as well as [packets.go][1], the final flag should be the first item in each payload packet in an encrypted message. However, the example currently places the final flag last in the payload packet, introducing ambiguity for those implementing the protocol. This commit changes the example to conform to the actual implementation behaviour.

[1]: https://github.com/keybase/saltpack/blob/e19b1910c0c5e2e309b248ea32d1d05e6b868dc4/packets.go#L62