### PR TITLE
Minor spec fixes

### DIFF
--- a/specs/saltpack.md
+++ b/specs/saltpack.md
@@ -18,8 +18,9 @@ We start with some simplifying decisions:
 - We'll use [MessagePack](http://msgpack.org/index.html) for all the binary
   formatting.
 
-Thus, "saltpack". The spec is in three parts:
+Thus, "saltpack". The spec is in four parts:
 
-- [a binary encryption format](saltpack_encryption.md)
-- [a binary signing format](saltpack_signing.md)
+- [a binary encryption format](saltpack_encryption_v2.md)
+- [a binary signcryption format](saltpack_signcryption_v2.md)
+- [a binary signing format](saltpack_signing_v2.md)
 - [an ASCII armor scheme](saltpack_armor.md)

--- a/specs/saltpack_encryption_v1.md
+++ b/specs/saltpack_encryption_v1.md
@@ -45,10 +45,10 @@ maliciously altering the message. For example, if Alice is sending to Bob and
 Charlie, Bob should not be able to rewrite the message and pass it to Charlie
 without Charlie detecting the attack.
 
-The message is chunked into 1MB chunks. A sequential nonce used for the
-encryption and MAC's ensures that the 1MB chunks cannot be reordered. The end
-of the message is marked with an empty chunk — encrypted and MAC'ed the same
-way — to prevent truncation attacks.
+The message is chunked into 1MiB (= 2^20 bytes) chunks. A sequential nonce used
+for the encryption and MAC's ensures that the 1MiB chunks cannot be reordered.
+The end of the message is marked with an empty chunk — encrypted and MAC'ed the
+same way — to prevent truncation attacks.
 
 Though the scheme is designed with the intent of having multiple per-device
 keys for each recipient, the implementation treats all recipient keys
@@ -228,7 +228,7 @@ A payload packet is a MessagePack array with these contents:
   message header. These are computed with the **MAC keys** derived from the
   header. See below.
 - The **payload secretbox** is a NaCl secretbox containing a chunk of the
-  plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. The
+  plaintext bytes, max size 1 MiB. It's encrypted with the **payload key**. The
   nonce is `saltpack_ploadsbNNNNNNNN` where `NNNNNNNN` is the packet number as
   an 8-byte big-endian unsigned integer. The first payload packet is number 0.
 

--- a/specs/saltpack_encryption_v2.md
+++ b/specs/saltpack_encryption_v2.md
@@ -152,7 +152,7 @@ header:
     with the recipient's public key, the sender's long-term private key, and
     the nonce from the previous step.
 12. Modify the nonce from step 10 by setting the least significant bit of byte
-    15. That is: `nonce[15] |= 0x01`.
+    15, i.e: `nonce[15] |= 0x01`.
 13. Encrypt 32 zero bytes again, as in step 11, but using the ephemeral private
     key rather than the sender's long term private key.
 14. Concatenate the last 32 bytes each box from steps 11 and 13. Take the

--- a/specs/saltpack_encryption_v2.md
+++ b/specs/saltpack_encryption_v2.md
@@ -35,10 +35,10 @@ maliciously altering the message. For example, if Alice is sending to Bob and
 Charlie, Bob should not be able to rewrite the message and pass it to Charlie
 without Charlie detecting the attack.
 
-The message is chunked into 1MB chunks. A sequential nonce used for the
-encryption and MAC's ensures that the 1MB chunks cannot be reordered. The end
-of the message is marked with an authenticated flag to prevent truncation
-attacks.
+The message is chunked into 1MiB (= 2^20 bytes) chunks. A sequential nonce used
+for the encryption and MAC's ensures that the 1MiB chunks cannot be reordered.
+The end of the message is marked with an authenticated flag to prevent
+truncation attacks.
 
 Though the scheme is designed with the intent of having multiple per-device
 keys for each recipient, the implementation treats all recipient keys
@@ -222,7 +222,7 @@ A payload packet is a MessagePack array with these contents:
   message header. These are computed with the **MAC keys** derived from the
   header. See below.
 - The **payload secretbox** is a NaCl secretbox containing a chunk of the
-  plaintext bytes, max size 1 MB. It's encrypted with the **payload key**. The
+  plaintext bytes, max size 1 MiB. It's encrypted with the **payload key**. The
   nonce is `saltpack_ploadsbNNNNNNNN` where `NNNNNNNN` is the packet number as
   an 8-byte big-endian unsigned integer. The first payload packet is number 0.
 

--- a/specs/saltpack_signcryption_v2.md
+++ b/specs/saltpack_signcryption_v2.md
@@ -24,10 +24,10 @@ shared with all recipients. The recipients may be either public Curve25519
 encryption keys, or long-term 32-byte symmetric secrets. It is then signed with
 a long-term signing key belonging to the sender.
 
-The message is chunked into 1MB chunks. A sequential nonce used for the
-encryption and MAC's ensures that the 1MB chunks cannot be reordered. The end
-of the message is marked with an authenticated flag to prevent truncation
-attacks.
+The message is chunked into 1MiB (= 2^20 bytes) chunks. A sequential nonce used
+for the encryption and MAC's ensures that the 1MiB chunks cannot be reordered.
+The end of the message is marked with an authenticated flag to prevent
+truncation attacks.
 
 As in the encryption mode, each encrypted copy of the message encryption key is
 given a recipient identifier. Unlike the encryption mode, signcryption doesn't
@@ -205,13 +205,13 @@ A payload packet is a MessagePack array with these contents:
 ]
 ```
 
-- The **signcrypted chunk** is a chunk of plaintext bytes, max size 1 MB,
+- The **signcrypted chunk** is a chunk of plaintext bytes, max size 1 MiB,
   signed by the **sender signing key** and encrypted with the **payload key**.
 - The **final flag** is a boolean, true for the final payload packet, and false
   for all other payload packets.
 
 The sender creates the **signcrypted chunk** with the following steps. For
-each 1 MB chunk of plaintext:
+each 1 MiB chunk of plaintext:
 
 1. Compute the **packet nonce**. Take the first 16 bytes of the **header
    hash**. If this is the final packet, set the least significant bit of the

--- a/specs/saltpack_signing_v1.md
+++ b/specs/saltpack_signing_v1.md
@@ -73,7 +73,8 @@ Payload packets are MessagePack arrays that look like this:
 ```
 
 - **signature** is a detached NaCl signature, 64 bytes.
-- **payload chunk** is a chunk of the plaintext bytes, max size 1 MB.
+- **payload chunk** is a chunk of the plaintext bytes, max size 1 MiB (= 2^20
+  bytes).
 
 To make each signature, the sender first takes the SHA512 hash of the
 concatenation of three values:

--- a/specs/saltpack_signing_v2.md
+++ b/specs/saltpack_signing_v2.md
@@ -73,7 +73,8 @@ Payload packets are MessagePack arrays that look like this:
 - **final flag** is a boolean, true for the final payload packet, and false for
   all other payload packets.
 - **signature** is a detached NaCl signature, 64 bytes.
-- **payload chunk** is a chunk of the plaintext bytes, max size 1 MB.
+- **payload chunk** is a chunk of the plaintext bytes, max size 1 MiB (= 2^20
+  bytes).
 
 To make each signature, the sender first takes the SHA512 hash of the
 concatenation of four values:


### PR DESCRIPTION
This PR just corrects a couple of tiny issues I had with the saltpack spec.

First, it changes uses of "MB" to be "MiB", and adds the definition of 1 MiB (= 2^20 bytes) the first time it is referred to in each page of the spec. This is a really tiny pedantic thing, but I had to double check with the Go implementation when implementing the spec from scratch myself, since people often mean 10^6 bytes when they say MB. No worries if you don't want to merge this one :smile:

Second, it updates `specs/saltpack.md` to be in line with the current working links to the parts of the spec, and fixes a very small formatting bug in `specs/saltpack_encryption_v2.md`, which makes it appear weirdly when the Markdown is parsed.

Thanks!